### PR TITLE
Suggestion: Context managers return single filename if only one file was processed

### DIFF
--- a/maestro_worker_python/convert_files.py
+++ b/maestro_worker_python/convert_files.py
@@ -23,6 +23,7 @@ class FileToConvert:
     output_file_path: str = None
     max_duration: int = 1200
 
+
 def convert_files(convert_files: List[FileToConvert]):
     logger.info(f"Converting {len(convert_files)} files")
 
@@ -39,26 +40,36 @@ def convert_files(convert_files: List[FileToConvert]):
 
     logger.info(f"Finished converting {len(convert_files)} files")
 
+
 @contextmanager
-def convert_files_manager(convert_files: List[FileToConvert]):
+def convert_files_manager(*convert_files: FileToConvert) -> None | str | list[str]:
     try:
         thread_list = []
         list_objects = []
         with concurrent.futures.ThreadPoolExecutor() as executor:
             for convert_file in convert_files:
-                file_format = '.m4a' if convert_file.file_format == "m4a" else '.wav'
+                file_format = ".m4a" if convert_file.file_format == "m4a" else ".wav"
                 filename = tempfile.NamedTemporaryFile(suffix=file_format)
                 target_function = _convert_to_m4a if convert_file.file_format == "m4a" else _convert_to_wav
                 thread_list.append(
-                    executor.submit(target_function, convert_file.input_file_path, filename.name, convert_file.max_duration)
+                    executor.submit(
+                        target_function, convert_file.input_file_path, filename.name, convert_file.max_duration
+                    )
                 )
                 list_objects.append(filename)
             for thread in thread_list:
                 thread.result()
-        yield [obj.name for obj in list_objects]
+        converted_files = [obj.name for obj in list_objects]
+        if len(converted_files) == 0:
+            yield None
+        elif len(converted_files) == 1:
+            yield converted_files[0]
+        else:
+            yield converted_files
     finally:
         for obj in list_objects:
             obj.close()
+
 
 def _convert_to_wav(input_file_path, output_file_path, max_duration):
     _run_subprocess(f"ffmpeg -y -hide_banner -loglevel error -t {max_duration} -i {input_file_path} -ar 44100 {output_file_path}")

--- a/tests/test_convert_files.py
+++ b/tests/test_convert_files.py
@@ -91,23 +91,26 @@ def test_should_convert_valid_audio_file():
     assert _get_hash(input_file_path) == _get_hash(output_file_path)
     Path(output_file_path).unlink(missing_ok=True)
 
+
 def test_should_convert_multiple_valid_audio_files_and_delete_after_context():
     input_file_path, output_file_path = TEST_PATH / "silent.ogg", TEST_PATH / "silent.wav"
     converted_files_list = []
     with convert_files_manager(
-        [FileToConvert(
+        FileToConvert(
             input_file_path=input_file_path,
             output_file_path=output_file_path,
             file_format="wav",
-        ), FileToConvert(
+        ),
+        FileToConvert(
             input_file_path=input_file_path,
             output_file_path=output_file_path,
             file_format="wav",
-        )]
+        ),
     ) as converted_files:
         converted_files_list = converted_files
     result = [os.path.exists(path) for path in converted_files_list]
     assert all(result) == False
+
 
 def _get_hash(file_name):
     process = subprocess.run(

--- a/tests/test_downlaod_file.py
+++ b/tests/test_downlaod_file.py
@@ -10,23 +10,25 @@ def test_download_file(httpserver):
     with open(file_name) as f:
         assert f.read() == "hello"
 
+
 def test_download_files_manager(httpserver):
     httpserver.expect_request("/test").respond_with_data("hello")
     url = httpserver.url_for("/test?foo=bar")
 
     files_content = []
-    with download_files_manager([url, url]) as downloaded_files:
+    with download_files_manager(url, url) as downloaded_files:
         for file in downloaded_files:
             with open(file) as f:
                 files_content.append(f.read() == "hello")
     assert all(files_content) == True
+
 
 def test_download_files_manager_delete(httpserver):
     httpserver.expect_request("/test").respond_with_data("hello")
     url = httpserver.url_for("/test?foo=bar")
 
     files_path_exists = []
-    with download_files_manager([url, url]) as downloaded_files:
+    with download_files_manager(url, url) as downloaded_files:
         files_path = downloaded_files
     for path in files_path:
         files_path_exists.append(os.path.exists(path))


### PR DESCRIPTION
This is just a suggestion. I think we know most of the time how many files we want to download, and often this is only one file (the audio). This change makes it a bit easier and cleaner to work with single files:
```python
with download_files_manager(input_url) as audio_file:
    result = process_audio(audio_file)
```
Before, we had to do:
```python
with download_files_manager([input_url]) as downloaded_files:
    audio_file = downloaded_files[0]
    result = process_audio(audio_file)
```
Multiple files can be passed as multiple arguments:
```python
with download_files_manager(audio_input_url, beats_input_url) as audio_file, beats_file:
    result = process_audio(audio_file, beats_file)
```
Let me know what you think.
