### PR TITLE
Add timeout of 5 minutes to download and upload requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 maestro_worker_python.egg-info
 __pycache__
 venv
+.vscode

--- a/maestro_worker_python/convert_files.py
+++ b/maestro_worker_python/convert_files.py
@@ -163,7 +163,7 @@ def _run_subprocess(command):
     else:
         if process.stderr:
             logger.warning(
-                "Non-falal error during conversion",
+                "Non-fatal error during conversion",
                 extra={
                     "props": {
                         "stderr": process.stderr.decode(),

--- a/maestro_worker_python/download_file.py
+++ b/maestro_worker_python/download_file.py
@@ -13,7 +13,7 @@ from .response import ValidationError
 
 def download_file(url: str, filename: str = None):
     logging.info(f"Downloading input: {url}")
-    response = requests.get(url, allow_redirects=True)
+    response = requests.get(url, allow_redirects=True, timeout=300)
 
     try:
         response.raise_for_status()

--- a/maestro_worker_python/upload_files.py
+++ b/maestro_worker_python/upload_files.py
@@ -40,7 +40,7 @@ def _upload(upload_file: UploadFile, did_raise_exception):
     logging.info(f"Uploading:{upload_file.file_path}")
     try:
         with open(upload_file.file_path, "rb") as data:
-            response = requests.put(upload_file.signed_url, data=data, headers={"Content-Type": upload_file.file_type})
+            response = requests.put(upload_file.signed_url, data=data, headers={"Content-Type": upload_file.file_type}, timeout=300)
             response.raise_for_status()
             logging.info(f"Uploaded {upload_file.file_path}")
     except Exception as e:


### PR DESCRIPTION
By default, Python [requests do not time out](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts), which means that we could have hangs that make a worker unusable when there are connection issues. See possible cases here: https://moises-ai.slack.com/archives/C03QKHFH1T3/p1705947008283499

I also ran into this problem when running the workers locally. The last log message was "INFO:root:Downloading input: ...", which comes from just before the [`requests.get()`](https://github.com/moises-ai/maestro-worker-python/blob/0ed49fca72bd6c54d5360f6954e41f70b3e6af0e/maestro_worker_python/download_file.py#L16).

Here I'm suggesting we use a timeout of 5 minutes for downloading and uploading files from GCS. This might be a good enough wait time since the network throughput is very high between GCE and GCS, but please make any considerations you may see fit.

Note that to apply this to all workers, we will have to update all of them to use the latest `maestro-worker-python`.