### PR TITLE
Add delete file endpoint to upload server

### DIFF
--- a/maestro_worker_python/upload_server.py
+++ b/maestro_worker_python/upload_server.py
@@ -24,6 +24,14 @@ async def get_file(filename: str):
     return f"File {filename} does not exist."
 
 
+@app.get("/delete-file/{filename}")
+async def delete_file(filename: str):
+    file_path = "uploads/" + filename
+    if os.path.exists(file_path):
+        os.remove(file_path)
+    return {"result": "OK"}
+
+
 @app.get("/clean")
 async def clean():
     for file in glob("uploads/*"):


### PR DESCRIPTION
Adds an endpoint to delete specific files in the upload server. It is useful to manage files only through the API instead of doing it on disk directly and when deleting all files is not desirable, like in `/clean`.

Added it as GET to `/delete-file/{filename}` to not break consistency with the other endpoints, even though using DELETE on `/file/{filename}` would likely be cleaner.