### PR TITLE
Replace json with orjson

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "maestro-worker-python"
-version = "3.5.1"
+version = "3.5.2"
 description = "Utility to run workers on Moises/Maestro"
 authors = ["Moises.ai"]
 license = "MIT"
@@ -15,6 +15,7 @@ json-logging = "^1.3.0"
 uvicorn = "^0.20"
 sentry-sdk = {extras = ["fastapi"], version = "^1.16.0"}
 requests = "2.31.0"
+orjson = "3.10.5"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Python's standard `json` library can produce invalid JSON files, for example if we serialize `nan`, `+inf` or `-inf` floating point values. 

I replaced it with `orjson`, which is faster and produces compliant JSON files.

One important difference is that `orjson` serializes to `bytes` instead of `str`. I checked with some files, and the results of the old serialization with `json` and `orjson` were exactly the same, so I think we're fine.