### PR TITLE
feat: load workers from files or modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Run the maestro server with the path to your worker. To see all options, use `ma
 maestro-server --worker=./worker.py
 ```
 
+Installed worker adapters can also be loaded by module name:
+
+```bash
+maestro-server --worker=my_package.worker
+```
+
 Send a request to the server inference endpoint:
 
 ```bash

--- a/maestro_worker_python/cli.py
+++ b/maestro_worker_python/cli.py
@@ -1,9 +1,11 @@
-from importlib.machinery import SourceFileLoader
 import logging
 import sys
 
+from .load_worker import load_worker
+
+
 def main():
-    worker = SourceFileLoader("worker",sys.argv[1]).load_module()
+    worker = load_worker(sys.argv[1])
     model = worker.MoisesWorker()
     params = {}
     for arg in sys.argv:

--- a/maestro_worker_python/init.py
+++ b/maestro_worker_python/init.py
@@ -14,7 +14,7 @@ def main():
     args = parser.parse_args().__dict__
 
     dir = pathlib.Path(__file__).parent.resolve()
-    print("""\
+    print(r"""
 ___  ___                _             
 |  \/  |               | |            
 | .  . | __ _  ___  ___| |_ _ __ ___  
@@ -28,7 +28,7 @@ ___  ___                _
     shutil.copy(f"{dir}/data/requirements.txt", f"{args.get('folder')}/requirements.txt")
     shutil.copy(f"{dir}/data/docker-compose.yaml", f"{args.get('folder')}/docker-compose.yaml")
     shutil.copy(f"{dir}/data/Dockerfile", f"{args.get('folder')}/Dockerfile")
-    os.mkdir(f"{args.get('folder')}/models")
+    os.makedirs(f"{args.get('folder')}/models", exist_ok=True)
     shutil.copy(f"{dir}/data/models/model.th", f"{args.get('folder')}/models/model.th")
     
 

--- a/maestro_worker_python/load_worker.py
+++ b/maestro_worker_python/load_worker.py
@@ -1,0 +1,39 @@
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def load_worker(reference: str) -> ModuleType:
+    """Load a worker from a Python file path or an importable module name."""
+    path = Path(reference)
+    if path.suffix != ".py" and not path.exists():
+        return importlib.import_module(reference)
+
+    path = path.resolve()
+    worker_dir = str(path.parent)
+    if worker_dir not in sys.path:
+        sys.path.insert(0, worker_dir)
+
+    search_locations = [worker_dir] if path.name == "__init__.py" else None
+    spec = importlib.util.spec_from_file_location(
+        "worker",
+        path,
+        submodule_search_locations=search_locations,
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load worker from {reference!r}")
+
+    module = importlib.util.module_from_spec(spec)
+    previous_module = sys.modules.get("worker")
+    sys.modules["worker"] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        if previous_module is None:
+            sys.modules.pop("worker", None)
+        else:
+            sys.modules["worker"] = previous_module
+        raise
+    return module

--- a/maestro_worker_python/serve.py
+++ b/maestro_worker_python/serve.py
@@ -12,10 +12,10 @@ from fastapi import FastAPI, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from starlette.concurrency import run_in_threadpool
-from importlib.machinery import SourceFileLoader
 from fastapi.middleware.cors import CORSMiddleware
 
 from .config import settings
+from .load_worker import load_worker
 from .response import ValidationError, WorkerResponse
 from .kill_process import terminate_current_process, kill_child_processes
 
@@ -57,7 +57,7 @@ if settings.enable_json_logging:
     json_logging.init_request_instrument(app)
     json_logging.config_root_logger()
 
-worker = SourceFileLoader("worker", settings.model_path).load_module()
+worker = load_worker(settings.model_path)
 model = worker.MoisesWorker()
 
 error_counter = 0

--- a/maestro_worker_python/server.py
+++ b/maestro_worker_python/server.py
@@ -8,7 +8,7 @@ def main():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--worker", default="./worker.py",
-                        help="Path to the Moises worker file that include a MoisesWorker class")
+                        help="Python file or importable module that contains a MoisesWorker class")
     parser.add_argument("--base_path", default="/",
                         help="DEPRECATED")
     parser.add_argument("--port", default=8000, help="Port to run uvicorn on")

--- a/tests/test_worker_loading.py
+++ b/tests/test_worker_loading.py
@@ -1,0 +1,49 @@
+import sys
+
+from maestro_worker_python.load_worker import load_worker
+
+
+def test_load_worker_file_supports_sibling_imports(tmp_path):
+    (tmp_path / "helper.py").write_text('MESSAGE = "loaded locally"\n')
+    worker_path = tmp_path / "worker.py"
+    worker_path.write_text("from helper import MESSAGE\n")
+
+    original_path = sys.path.copy()
+    try:
+        module = load_worker(str(worker_path))
+    finally:
+        sys.path = original_path
+        sys.modules.pop("helper", None)
+        sys.modules.pop("worker", None)
+
+    assert module.MESSAGE == "loaded locally"
+
+
+def test_load_worker_imports_module_reference(tmp_path, monkeypatch):
+    module_name = "maestro_test_adapter"
+    (tmp_path / f"{module_name}.py").write_text('MARKER = "loaded by name"\n')
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    try:
+        module = load_worker(module_name)
+    finally:
+        sys.modules.pop(module_name, None)
+
+    assert module.MARKER == "loaded by name"
+
+
+def test_load_worker_package_supports_relative_imports(tmp_path):
+    worker_dir = tmp_path / "worker"
+    worker_dir.mkdir()
+    (worker_dir / "helper.py").write_text('MESSAGE = "loaded relatively"\n')
+    (worker_dir / "__init__.py").write_text("from .helper import MESSAGE\n")
+
+    original_path = sys.path.copy()
+    try:
+        module = load_worker(str(worker_dir / "__init__.py"))
+    finally:
+        sys.path = original_path
+        sys.modules.pop("worker.helper", None)
+        sys.modules.pop("worker", None)
+
+    assert module.MESSAGE == "loaded relatively"


### PR DESCRIPTION
## Summary
- Add `load_worker()` so `--worker` accepts a Python file path or an importable module name (e.g. `my_package.worker`).
- Wire CLI/server through the shared loader and document module loading in the README.
- Make `maestro-init` re-runnable (`models/` with `exist_ok`) and silence the banner escape `SyntaxWarning`.

## Test plan
- [x] `uv run pytest`
- [x] `maestro-server --worker=./worker.py` still loads a local file worker
- [x] `maestro-server --worker=<importable.module>` loads an installed adapter
- [x] Re-run `maestro-init` in a folder that already has `models/` and confirm it no longer crashes