### PR TITLE
feat: expose worker hardware health metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.egg-info/
 __pycache__/
+.pytest_cache/
 .venv/
 venv/
 .vscode/

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ Send a request to the server inference endpoint:
 curl --request POST --url http://localhost:8000/inference  --header 'Content-Type: application/json' \
     --data '{"input_1": "Hello"}'
 ```
+
+The `/health` endpoint reports the Maestro worker package version and available
+GPU metadata in addition to `ok`. NVIDIA probing is best-effort, so CPU workers
+return an empty `hardware.gpus` list. MIG instances are counted when visible;
+MPS reports its active-thread percentage when configured, but cannot reliably
+infer the total number of clients.
+
 ### Upload/Download server for development purposes
 In order to avoid using signedurls for uploading/downloading files, you can use the `maestro-upload-server` command. This will start a server in the default `9090` port that will upload/download files in the local `./uploads` folder.
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,11 @@ curl --request POST --url http://localhost:8000/inference  --header 'Content-Typ
 The `/health` endpoint reports the Maestro worker package version and available
 GPU metadata in addition to `ok`. CUDA provenance is explicit:
 `driver_supported_version` is the newest CUDA version supported by the host
-driver, `container_version` comes from the image's `CUDA_VERSION`, and
-`torch_build_version` is the toolkit version used to build an already-imported
-PyTorch. NVIDIA probing is best-effort, so CPU workers return an empty
-`hardware.gpus` list. MIG instances are counted when visible; MPS reports its
-active-thread percentage when configured, but cannot reliably infer the total
-number of clients.
+driver, while `torch_build_version` is the toolkit version used to build an
+already-imported PyTorch. NVIDIA probing is best-effort, so CPU workers return
+an empty `hardware.gpus` list. MIG instances are counted when visible; MPS
+reports its active-thread percentage when configured, but cannot reliably infer
+the total number of clients.
 
 ### Upload/Download server for development purposes
 In order to avoid using signedurls for uploading/downloading files, you can use the `maestro-upload-server` command. This will start a server in the default `9090` port that will upload/download files in the local `./uploads` folder.

--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ GPU metadata in addition to `ok`. `nvidia_driver_version` is the host driver,
 `driver_supported_version` is the newest CUDA version it supports, and
 `torch_build_version` is the toolkit version used to build an already-imported
 PyTorch. NVIDIA host probing uses NVML and is best-effort, so CPU workers return
-an empty `hardware.gpus` list. Active MIG instances are counted when visible;
-MPS reports its configured active-thread percentage and pinned-device-memory
-limit. These client settings can be further constrained by the MPS daemon, so
-they are not presented as effective limits and cannot reliably reveal the total
-number of clients. Once an already-imported PyTorch has initialized CUDA,
+an empty `hardware.gpus` list. Visible MIG partitions report their GPU-instance
+slice count, compute-instance slice count, and memory size. MPS reports its
+configured active-thread percentage and pinned-device-memory limit. These
+client settings can be further constrained by the MPS daemon, so they are not
+presented as effective limits and cannot reliably reveal the total number of
+clients. Once an already-imported PyTorch has initialized CUDA,
 `observed_sm_count` reports the SMs available to its current CUDA device without
 making the health check initialize CUDA itself.
 

--- a/README.md
+++ b/README.md
@@ -62,10 +62,14 @@ curl --request POST --url http://localhost:8000/inference  --header 'Content-Typ
 ```
 
 The `/health` endpoint reports the Maestro worker package version and available
-GPU metadata in addition to `ok`. NVIDIA probing is best-effort, so CPU workers
-return an empty `hardware.gpus` list. MIG instances are counted when visible;
-MPS reports its active-thread percentage when configured, but cannot reliably
-infer the total number of clients.
+GPU metadata in addition to `ok`. CUDA provenance is explicit:
+`driver_supported_version` is the newest CUDA version supported by the host
+driver, `container_version` comes from the image's `CUDA_VERSION`, and
+`torch_build_version` is the toolkit version used to build an already-imported
+PyTorch. NVIDIA probing is best-effort, so CPU workers return an empty
+`hardware.gpus` list. MIG instances are counted when visible; MPS reports its
+active-thread percentage when configured, but cannot reliably infer the total
+number of clients.
 
 ### Upload/Download server for development purposes
 In order to avoid using signedurls for uploading/downloading files, you can use the `maestro-upload-server` command. This will start a server in the default `9090` port that will upload/download files in the local `./uploads` folder.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ an empty `hardware.gpus` list. Active MIG instances are counted when visible;
 MPS reports its configured active-thread percentage and pinned-device-memory
 limit. These client settings can be further constrained by the MPS daemon, so
 they are not presented as effective limits and cannot reliably reveal the total
-number of clients.
+number of clients. Once an already-imported PyTorch has initialized CUDA,
+`observed_sm_count` reports the SMs available to its current CUDA device without
+making the health check initialize CUDA itself.
 
 ### Upload/Download server for development purposes
 In order to avoid using signedurls for uploading/downloading files, you can use the `maestro-upload-server` command. This will start a server in the default `9090` port that will upload/download files in the local `./uploads` folder.

--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ curl --request POST --url http://localhost:8000/inference  --header 'Content-Typ
 ```
 
 The `/health` endpoint reports the Maestro worker package version and available
-GPU metadata in addition to `ok`. CUDA provenance is explicit:
-`driver_supported_version` is the newest CUDA version supported by the host
-driver, while `torch_build_version` is the toolkit version used to build an
-already-imported PyTorch. NVIDIA probing is best-effort, so CPU workers return
-an empty `hardware.gpus` list. MIG instances are counted when visible; MPS
-reports its active-thread percentage when configured, but cannot reliably infer
-the total number of clients.
+GPU metadata in addition to `ok`. `nvidia_driver_version` is the host driver,
+`driver_supported_version` is the newest CUDA version it supports, and
+`torch_build_version` is the toolkit version used to build an already-imported
+PyTorch. NVIDIA host probing uses NVML and is best-effort, so CPU workers return
+an empty `hardware.gpus` list. Active MIG instances are counted when visible;
+MPS reports its active-thread percentage when configured, but cannot reliably
+infer the total number of clients.
 
 ### Upload/Download server for development purposes
 In order to avoid using signedurls for uploading/downloading files, you can use the `maestro-upload-server` command. This will start a server in the default `9090` port that will upload/download files in the local `./uploads` folder.

--- a/README.md
+++ b/README.md
@@ -67,8 +67,10 @@ GPU metadata in addition to `ok`. `nvidia_driver_version` is the host driver,
 `torch_build_version` is the toolkit version used to build an already-imported
 PyTorch. NVIDIA host probing uses NVML and is best-effort, so CPU workers return
 an empty `hardware.gpus` list. Active MIG instances are counted when visible;
-MPS reports its active-thread percentage when configured, but cannot reliably
-infer the total number of clients.
+MPS reports its configured active-thread percentage and pinned-device-memory
+limit. These client settings can be further constrained by the MPS daemon, so
+they are not presented as effective limits and cannot reliably reveal the total
+number of clients.
 
 ### Upload/Download server for development purposes
 In order to avoid using signedurls for uploading/downloading files, you can use the `maestro-upload-server` command. This will start a server in the default `9090` port that will upload/download files in the local `./uploads` folder.

--- a/maestro_worker_python/health.py
+++ b/maestro_worker_python/health.py
@@ -161,6 +161,25 @@ def _torch_cuda_version() -> str | None:
     return getattr(getattr(torch, "version", None), "cuda", None)
 
 
+def _torch_observed_sm_count() -> int | None:
+    """SMs visible to an already-initialized Torch CUDA runtime."""
+    torch = sys.modules.get("torch")
+    cuda = getattr(torch, "cuda", None)
+    is_initialized = getattr(cuda, "is_initialized", None)
+    if not callable(is_initialized):
+        return None
+
+    try:
+        if not is_initialized():
+            return None
+        device = cuda.current_device()
+        sm_count = cuda.get_device_properties(device).multi_processor_count
+    except Exception:
+        return None
+
+    return sm_count if isinstance(sm_count, int) and sm_count > 0 else None
+
+
 def _worker_version() -> str:
     try:
         return metadata.version("maestro-worker-python")
@@ -183,10 +202,18 @@ def _get_host_metadata() -> dict[str, Any]:
 
 def _with_process_metadata(host_metadata: dict[str, Any]) -> dict[str, Any]:
     hardware = host_metadata["hardware"]
+    partitioning = hardware["partitioning"]
+    if partitioning and partitioning["method"] == "mps":
+        partitioning = {
+            **partitioning,
+            "observed_sm_count": _torch_observed_sm_count(),
+        }
+
     return {
         **host_metadata,
         "hardware": {
             **hardware,
+            "partitioning": partitioning,
             "cuda": {
                 **hardware["cuda"],
                 "torch_build_version": _torch_cuda_version(),

--- a/maestro_worker_python/health.py
+++ b/maestro_worker_python/health.py
@@ -23,11 +23,14 @@ def _run_nvidia_smi(*args: str) -> str | None:
     return result.stdout
 
 
-def _partitioning_metadata(visible_mig_devices: int) -> dict[str, Any] | None:
-    if visible_mig_devices:
+def _partitioning_metadata(
+    visible_mig_partitions: list[dict[str, int | None]],
+) -> dict[str, Any] | None:
+    if visible_mig_partitions:
         return {
             "method": "mig",
-            "visible_partition_count": visible_mig_devices,
+            "visible_partition_count": len(visible_mig_partitions),
+            "visible_partitions": visible_mig_partitions,
         }
 
     configured_active_thread_percentage = None
@@ -66,15 +69,65 @@ def _nvidia_smi_driver_supported_cuda_version() -> str | None:
     return match.group(1) if match else None
 
 
-def _nvml_gpu_metadata() -> tuple[list[dict[str, str | None]], int]:
-    """Collect visible physical GPUs and their visible active MIG devices."""
+def _nvml_mig_partition_metadata(device: Any) -> dict[str, int | None]:
+    try:
+        attributes = pynvml.nvmlDeviceGetAttributes(device)
+    except pynvml.NVMLError:
+        return {
+            "gpu_instance_slice_count": None,
+            "compute_instance_slice_count": None,
+            "memory_size_mb": None,
+        }
+
+    return {
+        "gpu_instance_slice_count": attributes.gpuInstanceSliceCount,
+        "compute_instance_slice_count": attributes.computeInstanceSliceCount,
+        "memory_size_mb": attributes.memorySizeMB,
+    }
+
+
+def _nvml_visible_mig_devices(device: Any) -> list[Any]:
+    try:
+        if pynvml.nvmlDeviceIsMigDeviceHandle(device):
+            return [device]
+    except pynvml.NVMLError:
+        pass
+
+    try:
+        max_mig_devices = pynvml.nvmlDeviceGetMaxMigDeviceCount(device)
+    except pynvml.NVMLError:
+        return []
+
+    mig_devices = []
+    for mig_index in range(max_mig_devices):
+        try:
+            mig_device = pynvml.nvmlDeviceGetMigDeviceHandleByIndex(device, mig_index)
+        except pynvml.NVMLError:
+            continue
+        mig_devices.append(mig_device)
+
+    return mig_devices
+
+
+def _nvml_device_identity(device: Any) -> str:
+    try:
+        return pynvml.nvmlDeviceGetUUID(device)
+    except pynvml.NVMLError:
+        return repr(device)
+
+
+def _nvml_gpu_metadata() -> tuple[
+    list[dict[str, str | None]], list[dict[str, int | None]]
+]:
+    """Collect visible GPUs and active MIG partitions."""
     try:
         device_count = pynvml.nvmlDeviceGetCount()
     except pynvml.NVMLError:
-        return [], 0
+        return [], []
 
     gpus = []
-    visible_mig_devices = 0
+    visible_mig_partitions = []
+    seen_mig_devices = set()
     for device_index in range(device_count):
         try:
             device = pynvml.nvmlDeviceGetHandleByIndex(device_index)
@@ -94,19 +147,16 @@ def _nvml_gpu_metadata() -> tuple[list[dict[str, str | None]], int]:
 
         gpus.append({"model": model, "sm_version": sm_version})
 
-        try:
-            max_mig_devices = pynvml.nvmlDeviceGetMaxMigDeviceCount(device)
-        except pynvml.NVMLError:
-            continue
-
-        for mig_index in range(max_mig_devices):
-            try:
-                pynvml.nvmlDeviceGetMigDeviceHandleByIndex(device, mig_index)
-            except pynvml.NVMLError:
+        for mig_device in _nvml_visible_mig_devices(device):
+            identity = _nvml_device_identity(mig_device)
+            if identity in seen_mig_devices:
                 continue
-            visible_mig_devices += 1
+            seen_mig_devices.add(identity)
+            visible_mig_partitions.append(
+                _nvml_mig_partition_metadata(mig_device)
+            )
 
-    return gpus, visible_mig_devices
+    return gpus, visible_mig_partitions
 
 
 def _collect_hardware_metadata() -> dict[str, Any]:
@@ -114,7 +164,7 @@ def _collect_hardware_metadata() -> dict[str, Any]:
     driver_version = None
     driver_supported_cuda_version = None
     gpus = []
-    visible_mig_devices = 0
+    visible_mig_partitions = []
 
     try:
         pynvml.nvmlInit()
@@ -135,7 +185,7 @@ def _collect_hardware_metadata() -> dict[str, Any]:
             except pynvml.NVMLError:
                 pass
 
-            gpus, visible_mig_devices = _nvml_gpu_metadata()
+            gpus, visible_mig_partitions = _nvml_gpu_metadata()
         finally:
             try:
                 pynvml.nvmlShutdown()
@@ -151,7 +201,7 @@ def _collect_hardware_metadata() -> dict[str, Any]:
             "driver_supported_version": driver_supported_cuda_version,
         },
         "gpus": gpus,
-        "partitioning": _partitioning_metadata(visible_mig_devices),
+        "partitioning": _partitioning_metadata(visible_mig_partitions),
     }
 
 

--- a/maestro_worker_python/health.py
+++ b/maestro_worker_python/health.py
@@ -30,21 +30,33 @@ def _partitioning_metadata(visible_mig_devices: int) -> dict[str, Any] | None:
             "visible_partition_count": visible_mig_devices,
         }
 
+    configured_active_thread_percentage = None
     active_thread_percentage = os.getenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE")
     if active_thread_percentage:
         try:
             percentage = int(active_thread_percentage)
         except ValueError:
-            return None
-        if 0 < percentage <= 100:
-            return {
-                "method": "mps",
-                "active_thread_percentage": percentage,
-                # MPS permits non-uniform client limits, so this percentage
-                # cannot reliably reveal the total number of clients.
-                "partition_count": None,
-            }
-    return None
+            percentage = None
+        if percentage is not None and 0 < percentage <= 100:
+            configured_active_thread_percentage = percentage
+
+    configured_pinned_device_memory_limit = (
+        os.getenv("CUDA_MPS_PINNED_DEVICE_MEM_LIMIT") or None
+    )
+    if (
+        configured_active_thread_percentage is None
+        and configured_pinned_device_memory_limit is None
+    ):
+        return None
+
+    return {
+        "method": "mps",
+        "configured_active_thread_percentage": configured_active_thread_percentage,
+        "configured_pinned_device_memory_limit": configured_pinned_device_memory_limit,
+        # MPS permits non-uniform client limits, so configured limits cannot
+        # reliably reveal the total number of clients.
+        "partition_count": None,
+    }
 
 
 def _nvidia_smi_driver_supported_cuda_version() -> str | None:

--- a/maestro_worker_python/health.py
+++ b/maestro_worker_python/health.py
@@ -8,6 +8,8 @@ from importlib import metadata
 from io import StringIO
 from typing import Any
 
+import pynvml
+
 
 def _run_nvidia_smi(*args: str) -> str | None:
     try:
@@ -77,11 +79,40 @@ def _partitioning_metadata() -> dict[str, Any] | None:
     return None
 
 
-def _driver_supported_cuda_version() -> str | None:
-    """Latest CUDA version supported by the host driver, as reported by nvidia-smi."""
-    output = _run_nvidia_smi() or ""
-    match = re.search(r"CUDA Version:\s*([0-9]+(?:\.[0-9]+)*)", output)
+def _nvml_driver_supported_cuda_version() -> str | None:
+    """Latest CUDA version supported by the host driver, as reported by NVML."""
+    try:
+        pynvml.nvmlInit()
+    except pynvml.NVMLError:
+        return None
+
+    try:
+        version = pynvml.nvmlSystemGetCudaDriverVersion_v2()
+    except pynvml.NVMLError:
+        return None
+    finally:
+        try:
+            pynvml.nvmlShutdown()
+        except pynvml.NVMLError:
+            pass
+
+    major = version // 1000
+    minor = (version % 1000) // 10
+    return f"{major}.{minor}"
+
+
+def _nvidia_smi_driver_supported_cuda_version() -> str | None:
+    """Fallback for environments where the NVML library cannot be queried."""
+    output = _run_nvidia_smi("-q") or ""
+    match = re.search(r"CUDA(?: UMD)? Version\s*:\s*([0-9]+(?:\.[0-9]+)*)", output)
     return match.group(1) if match else None
+
+
+def _driver_supported_cuda_version() -> str | None:
+    return (
+        _nvml_driver_supported_cuda_version()
+        or _nvidia_smi_driver_supported_cuda_version()
+    )
 
 
 def _torch_cuda_version() -> str | None:
@@ -98,13 +129,12 @@ def _worker_version() -> str:
 
 
 def _collect_host_metadata() -> dict[str, Any]:
-    """Collect stable host/container metadata without making health depend on a GPU."""
+    """Collect stable host metadata without making health depend on a GPU."""
     return {
         "worker_version": _worker_version(),
         "hardware": {
             "cuda": {
                 "driver_supported_version": _driver_supported_cuda_version(),
-                "container_version": os.getenv("CUDA_VERSION"),
             },
             "gpus": _gpu_metadata(),
             "partitioning": _partitioning_metadata(),

--- a/maestro_worker_python/health.py
+++ b/maestro_worker_python/health.py
@@ -1,11 +1,9 @@
-import csv
 import os
 import re
 import subprocess
 import sys
 from functools import lru_cache
 from importlib import metadata
-from io import StringIO
 from typing import Any
 
 import pynvml
@@ -25,37 +23,7 @@ def _run_nvidia_smi(*args: str) -> str | None:
     return result.stdout
 
 
-def _gpu_metadata() -> list[dict[str, str | None]]:
-    output = _run_nvidia_smi(
-        "--query-gpu=name,driver_version,compute_cap",
-        "--format=csv,noheader,nounits",
-    )
-    if not output:
-        return []
-
-    gpus = []
-    for row in csv.reader(StringIO(output), skipinitialspace=True):
-        if len(row) != 3:
-            continue
-        model, driver_version, compute_capability = (value.strip() for value in row)
-        sm_version = None
-        if compute_capability and compute_capability.lower() not in {"n/a", "[n/a]"}:
-            sm_version = f"sm_{compute_capability.replace('.', '')}"
-        gpus.append(
-            {
-                "model": model or None,
-                "driver_version": driver_version or None,
-                "sm_version": sm_version,
-            }
-        )
-    return gpus
-
-
-def _partitioning_metadata() -> dict[str, Any] | None:
-    device_list = _run_nvidia_smi("-L") or ""
-    visible_mig_devices = sum(
-        line.strip().startswith("MIG ") for line in device_list.splitlines()
-    )
+def _partitioning_metadata(visible_mig_devices: int) -> dict[str, Any] | None:
     if visible_mig_devices:
         return {
             "method": "mig",
@@ -79,40 +47,100 @@ def _partitioning_metadata() -> dict[str, Any] | None:
     return None
 
 
-def _nvml_driver_supported_cuda_version() -> str | None:
-    """Latest CUDA version supported by the host driver, as reported by NVML."""
-    try:
-        pynvml.nvmlInit()
-    except pynvml.NVMLError:
-        return None
-
-    try:
-        version = pynvml.nvmlSystemGetCudaDriverVersion_v2()
-    except pynvml.NVMLError:
-        return None
-    finally:
-        try:
-            pynvml.nvmlShutdown()
-        except pynvml.NVMLError:
-            pass
-
-    major = version // 1000
-    minor = (version % 1000) // 10
-    return f"{major}.{minor}"
-
-
 def _nvidia_smi_driver_supported_cuda_version() -> str | None:
-    """Fallback for environments where the NVML library cannot be queried."""
+    """Fallback for environments where NVML cannot query the CUDA driver."""
     output = _run_nvidia_smi("-q") or ""
     match = re.search(r"CUDA(?: UMD)? Version\s*:\s*([0-9]+(?:\.[0-9]+)*)", output)
     return match.group(1) if match else None
 
 
-def _driver_supported_cuda_version() -> str | None:
-    return (
-        _nvml_driver_supported_cuda_version()
-        or _nvidia_smi_driver_supported_cuda_version()
-    )
+def _nvml_gpu_metadata() -> tuple[list[dict[str, str | None]], int]:
+    """Collect visible physical GPUs and their visible active MIG devices."""
+    try:
+        device_count = pynvml.nvmlDeviceGetCount()
+    except pynvml.NVMLError:
+        return [], 0
+
+    gpus = []
+    visible_mig_devices = 0
+    for device_index in range(device_count):
+        try:
+            device = pynvml.nvmlDeviceGetHandleByIndex(device_index)
+        except pynvml.NVMLError:
+            continue
+
+        try:
+            model = pynvml.nvmlDeviceGetName(device)
+        except pynvml.NVMLError:
+            model = None
+
+        try:
+            major, minor = pynvml.nvmlDeviceGetCudaComputeCapability(device)
+            sm_version = f"sm_{major}{minor}"
+        except pynvml.NVMLError:
+            sm_version = None
+
+        gpus.append({"model": model, "sm_version": sm_version})
+
+        try:
+            max_mig_devices = pynvml.nvmlDeviceGetMaxMigDeviceCount(device)
+        except pynvml.NVMLError:
+            continue
+
+        for mig_index in range(max_mig_devices):
+            try:
+                pynvml.nvmlDeviceGetMigDeviceHandleByIndex(device, mig_index)
+            except pynvml.NVMLError:
+                continue
+            visible_mig_devices += 1
+
+    return gpus, visible_mig_devices
+
+
+def _collect_hardware_metadata() -> dict[str, Any]:
+    """Collect best-effort hardware metadata through one NVML session."""
+    driver_version = None
+    driver_supported_cuda_version = None
+    gpus = []
+    visible_mig_devices = 0
+
+    try:
+        pynvml.nvmlInit()
+    except pynvml.NVMLError:
+        pass
+    else:
+        try:
+            try:
+                driver_version = pynvml.nvmlSystemGetDriverVersion()
+            except pynvml.NVMLError:
+                pass
+
+            try:
+                cuda_version = pynvml.nvmlSystemGetCudaDriverVersion_v2()
+                major = cuda_version // 1000
+                minor = (cuda_version % 1000) // 10
+                driver_supported_cuda_version = f"{major}.{minor}"
+            except pynvml.NVMLError:
+                pass
+
+            gpus, visible_mig_devices = _nvml_gpu_metadata()
+        finally:
+            try:
+                pynvml.nvmlShutdown()
+            except pynvml.NVMLError:
+                pass
+
+    if driver_supported_cuda_version is None:
+        driver_supported_cuda_version = _nvidia_smi_driver_supported_cuda_version()
+
+    return {
+        "nvidia_driver_version": driver_version,
+        "cuda": {
+            "driver_supported_version": driver_supported_cuda_version,
+        },
+        "gpus": gpus,
+        "partitioning": _partitioning_metadata(visible_mig_devices),
+    }
 
 
 def _torch_cuda_version() -> str | None:
@@ -132,13 +160,7 @@ def _collect_host_metadata() -> dict[str, Any]:
     """Collect stable host metadata without making health depend on a GPU."""
     return {
         "worker_version": _worker_version(),
-        "hardware": {
-            "cuda": {
-                "driver_supported_version": _driver_supported_cuda_version(),
-            },
-            "gpus": _gpu_metadata(),
-            "partitioning": _partitioning_metadata(),
-        },
+        "hardware": _collect_hardware_metadata(),
     }
 
 

--- a/maestro_worker_python/health.py
+++ b/maestro_worker_python/health.py
@@ -1,0 +1,107 @@
+import csv
+import os
+import subprocess
+import sys
+from functools import lru_cache
+from importlib import metadata
+from io import StringIO
+from typing import Any
+
+
+def _run_nvidia_smi(*args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", *args],
+            capture_output=True,
+            check=True,
+            text=True,
+            timeout=2,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return None
+    return result.stdout
+
+
+def _gpu_metadata() -> list[dict[str, str | None]]:
+    output = _run_nvidia_smi(
+        "--query-gpu=name,driver_version,compute_cap",
+        "--format=csv,noheader,nounits",
+    )
+    if not output:
+        return []
+
+    gpus = []
+    for row in csv.reader(StringIO(output), skipinitialspace=True):
+        if len(row) != 3:
+            continue
+        model, driver_version, compute_capability = (value.strip() for value in row)
+        sm_version = None
+        if compute_capability and compute_capability.lower() not in {"n/a", "[n/a]"}:
+            sm_version = f"sm_{compute_capability.replace('.', '')}"
+        gpus.append(
+            {
+                "model": model or None,
+                "driver_version": driver_version or None,
+                "sm_version": sm_version,
+            }
+        )
+    return gpus
+
+
+def _partitioning_metadata() -> dict[str, Any] | None:
+    device_list = _run_nvidia_smi("-L") or ""
+    visible_mig_devices = sum(
+        line.strip().startswith("MIG ") for line in device_list.splitlines()
+    )
+    if visible_mig_devices:
+        return {
+            "method": "mig",
+            "visible_partition_count": visible_mig_devices,
+        }
+
+    active_thread_percentage = os.getenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE")
+    if active_thread_percentage:
+        try:
+            percentage = int(active_thread_percentage)
+        except ValueError:
+            return None
+        if 0 < percentage <= 100:
+            return {
+                "method": "mps",
+                "active_thread_percentage": percentage,
+                # MPS permits non-uniform client limits, so this percentage
+                # cannot reliably reveal the total number of clients.
+                "partition_count": None,
+            }
+    return None
+
+
+def _cuda_version() -> str | None:
+    torch = sys.modules.get("torch")
+    torch_version = getattr(getattr(torch, "version", None), "cuda", None)
+    return torch_version or os.getenv("CUDA_VERSION")
+
+
+def _worker_version() -> str:
+    try:
+        return metadata.version("maestro-worker-python")
+    except metadata.PackageNotFoundError:
+        return "unknown"
+
+
+def collect_health_metadata() -> dict[str, Any]:
+    """Collect stable runtime metadata without making health depend on a GPU."""
+    return {
+        "worker_version": _worker_version(),
+        "hardware": {
+            "cuda_version": _cuda_version(),
+            "gpus": _gpu_metadata(),
+            "partitioning": _partitioning_metadata(),
+        },
+    }
+
+
+@lru_cache(maxsize=1)
+def get_health_metadata() -> dict[str, Any]:
+    """Return process-lifetime metadata; hardware does not change at runtime."""
+    return collect_health_metadata()

--- a/maestro_worker_python/health.py
+++ b/maestro_worker_python/health.py
@@ -1,5 +1,6 @@
 import csv
 import os
+import re
 import subprocess
 import sys
 from functools import lru_cache
@@ -76,10 +77,17 @@ def _partitioning_metadata() -> dict[str, Any] | None:
     return None
 
 
-def _cuda_version() -> str | None:
+def _driver_supported_cuda_version() -> str | None:
+    """Latest CUDA version supported by the host driver, as reported by nvidia-smi."""
+    output = _run_nvidia_smi() or ""
+    match = re.search(r"CUDA Version:\s*([0-9]+(?:\.[0-9]+)*)", output)
+    return match.group(1) if match else None
+
+
+def _torch_cuda_version() -> str | None:
+    """CUDA toolkit version used to build an already-imported torch module."""
     torch = sys.modules.get("torch")
-    torch_version = getattr(getattr(torch, "version", None), "cuda", None)
-    return torch_version or os.getenv("CUDA_VERSION")
+    return getattr(getattr(torch, "version", None), "cuda", None)
 
 
 def _worker_version() -> str:
@@ -89,12 +97,15 @@ def _worker_version() -> str:
         return "unknown"
 
 
-def collect_health_metadata() -> dict[str, Any]:
-    """Collect stable runtime metadata without making health depend on a GPU."""
+def _collect_host_metadata() -> dict[str, Any]:
+    """Collect stable host/container metadata without making health depend on a GPU."""
     return {
         "worker_version": _worker_version(),
         "hardware": {
-            "cuda_version": _cuda_version(),
+            "cuda": {
+                "driver_supported_version": _driver_supported_cuda_version(),
+                "container_version": os.getenv("CUDA_VERSION"),
+            },
             "gpus": _gpu_metadata(),
             "partitioning": _partitioning_metadata(),
         },
@@ -102,6 +113,29 @@ def collect_health_metadata() -> dict[str, Any]:
 
 
 @lru_cache(maxsize=1)
+def _get_host_metadata() -> dict[str, Any]:
+    return _collect_host_metadata()
+
+
+def _with_process_metadata(host_metadata: dict[str, Any]) -> dict[str, Any]:
+    hardware = host_metadata["hardware"]
+    return {
+        **host_metadata,
+        "hardware": {
+            **hardware,
+            "cuda": {
+                **hardware["cuda"],
+                "torch_build_version": _torch_cuda_version(),
+            },
+        },
+    }
+
+
+def collect_health_metadata() -> dict[str, Any]:
+    """Collect fresh host and process metadata."""
+    return _with_process_metadata(_collect_host_metadata())
+
+
 def get_health_metadata() -> dict[str, Any]:
-    """Return process-lifetime metadata; hardware does not change at runtime."""
-    return collect_health_metadata()
+    """Return cached host metadata plus current process-local metadata."""
+    return _with_process_metadata(_get_host_metadata())

--- a/maestro_worker_python/serve.py
+++ b/maestro_worker_python/serve.py
@@ -15,6 +15,7 @@ from starlette.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
 
 from .config import settings
+from .health import get_health_metadata
 from .load_worker import load_worker
 from .response import ValidationError, WorkerResponse
 from .kill_process import terminate_current_process, kill_child_processes
@@ -109,7 +110,7 @@ async def index(request: Request):
 
 @app.get("/health")
 async def health(request: Request):
-    return {"ok": True}
+    return {"ok": True, **get_health_metadata()}
 
 
 @app.on_event("shutdown")
@@ -121,6 +122,8 @@ def shutdown_event():
 
 @app.on_event("startup")
 def startup_event():
+    # Prime the cache before readiness probes start hitting /health.
+    get_health_metadata()
     # Create a file to indicate that the server is running
     with open("/tmp/http_ready", "a") as f:
         f.write("Ready to serve")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [{ name = "Moises.ai" }]
 dependencies = [
   "fastapi>=0.100.0,<0.115.13",
   "json-logging>=1.3,<2",
+  "nvidia-ml-py>=12.535,<14",
   "psutil>=6.0.0,<7.1",
   "pydantic-core>=2.9,<3",
   "pydantic-settings>=2.9,<3",

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,66 @@
+from maestro_worker_python import health
+
+
+def test_collect_health_metadata_reports_gpu_and_mig(monkeypatch):
+    def run_nvidia_smi(*args):
+        if args == ("--query-gpu=name,driver_version,compute_cap", "--format=csv,noheader,nounits"):
+            return "NVIDIA L4, 570.148.08, 8.9\n"
+        if args == ("-L",):
+            return (
+                "GPU 0: NVIDIA A100 (UUID: GPU-1)\n"
+                "  MIG 1g.10gb Device 0: (UUID: MIG-1)\n"
+                "  MIG 1g.10gb Device 1: (UUID: MIG-2)\n"
+            )
+        raise AssertionError(args)
+
+    monkeypatch.setattr(health, "_run_nvidia_smi", run_nvidia_smi)
+    monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
+    monkeypatch.setenv("CUDA_VERSION", "13.0.2")
+
+    assert health.collect_health_metadata() == {
+        "worker_version": "4.2.0",
+        "hardware": {
+            "cuda_version": "13.0.2",
+            "gpus": [
+                {
+                    "model": "NVIDIA L4",
+                    "driver_version": "570.148.08",
+                    "sm_version": "sm_89",
+                }
+            ],
+            "partitioning": {
+                "method": "mig",
+                "visible_partition_count": 2,
+            },
+        },
+    }
+
+
+def test_collect_health_metadata_degrades_without_nvidia(monkeypatch):
+    monkeypatch.setattr(health, "_run_nvidia_smi", lambda *_args: None)
+    monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
+    monkeypatch.delenv("CUDA_VERSION", raising=False)
+    monkeypatch.delenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE", raising=False)
+
+    assert health.collect_health_metadata() == {
+        "worker_version": "4.2.0",
+        "hardware": {
+            "cuda_version": None,
+            "gpus": [],
+            "partitioning": None,
+        },
+    }
+
+
+def test_collect_health_metadata_reports_detectable_mps_limit(monkeypatch):
+    monkeypatch.setattr(health, "_run_nvidia_smi", lambda *_args: "")
+    monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
+    monkeypatch.setenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE", "50")
+
+    metadata = health.collect_health_metadata()
+
+    assert metadata["hardware"]["partitioning"] == {
+        "method": "mps",
+        "active_thread_percentage": 50,
+        "partition_count": None,
+    }

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,14 +1,75 @@
 import sys
 from types import SimpleNamespace
 
+import pytest
+
 from maestro_worker_python import health
+
+
+def test_nvml_driver_supported_cuda_version(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(health.pynvml, "nvmlInit", lambda: calls.append("init"))
+    monkeypatch.setattr(
+        health.pynvml,
+        "nvmlSystemGetCudaDriverVersion_v2",
+        lambda: calls.append("query") or 13030,
+    )
+    monkeypatch.setattr(health.pynvml, "nvmlShutdown", lambda: calls.append("shutdown"))
+
+    assert health._nvml_driver_supported_cuda_version() == "13.3"
+    assert calls == ["init", "query", "shutdown"]
+
+
+def test_nvml_driver_supported_cuda_version_shuts_down_after_query_error(monkeypatch):
+    calls = []
+
+    def query():
+        calls.append("query")
+        raise health.pynvml.NVMLError(health.pynvml.NVML_ERROR_UNKNOWN)
+
+    monkeypatch.setattr(health.pynvml, "nvmlInit", lambda: calls.append("init"))
+    monkeypatch.setattr(health.pynvml, "nvmlSystemGetCudaDriverVersion_v2", query)
+    monkeypatch.setattr(health.pynvml, "nvmlShutdown", lambda: calls.append("shutdown"))
+
+    assert health._nvml_driver_supported_cuda_version() is None
+    assert calls == ["init", "query", "shutdown"]
+
+
+def test_nvml_driver_supported_cuda_version_degrades_when_initialization_fails(
+    monkeypatch,
+):
+    def init():
+        raise health.pynvml.NVMLError(health.pynvml.NVML_ERROR_LIBRARY_NOT_FOUND)
+
+    monkeypatch.setattr(health.pynvml, "nvmlInit", init)
+    monkeypatch.setattr(
+        health.pynvml,
+        "nvmlShutdown",
+        lambda: pytest.fail("NVML must not be shut down after failed initialization"),
+    )
+
+    assert health._nvml_driver_supported_cuda_version() is None
+
+
+@pytest.mark.parametrize("label", ["CUDA Version", "CUDA UMD Version"])
+def test_driver_supported_cuda_version_falls_back_to_nvidia_smi(monkeypatch, label):
+    monkeypatch.setattr(health, "_nvml_driver_supported_cuda_version", lambda: None)
+    monkeypatch.setattr(
+        health,
+        "_run_nvidia_smi",
+        lambda *args: f"{label} : 13.3\n" if args == ("-q",) else None,
+    )
+
+    assert health._driver_supported_cuda_version() == "13.3"
 
 
 def test_collect_health_metadata_reports_gpu_and_mig(monkeypatch):
     def run_nvidia_smi(*args):
-        if not args:
-            return "| NVIDIA-SMI 570.148.08  Driver Version: 570.148.08  CUDA Version: 13.3 |\n"
-        if args == ("--query-gpu=name,driver_version,compute_cap", "--format=csv,noheader,nounits"):
+        if args == (
+            "--query-gpu=name,driver_version,compute_cap",
+            "--format=csv,noheader,nounits",
+        ):
             return "NVIDIA L4, 570.148.08, 8.9\n"
         if args == ("-L",):
             return (
@@ -18,17 +79,18 @@ def test_collect_health_metadata_reports_gpu_and_mig(monkeypatch):
             )
         raise AssertionError(args)
 
+    monkeypatch.setattr(health, "_nvml_driver_supported_cuda_version", lambda: "13.3")
     monkeypatch.setattr(health, "_run_nvidia_smi", run_nvidia_smi)
     monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
-    monkeypatch.setenv("CUDA_VERSION", "13.0.2")
-    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(version=SimpleNamespace(cuda="12.4")))
+    monkeypatch.setitem(
+        sys.modules, "torch", SimpleNamespace(version=SimpleNamespace(cuda="12.4"))
+    )
 
     assert health.collect_health_metadata() == {
         "worker_version": "4.2.0",
         "hardware": {
             "cuda": {
                 "driver_supported_version": "13.3",
-                "container_version": "13.0.2",
                 "torch_build_version": "12.4",
             },
             "gpus": [
@@ -47,9 +109,9 @@ def test_collect_health_metadata_reports_gpu_and_mig(monkeypatch):
 
 
 def test_collect_health_metadata_degrades_without_nvidia(monkeypatch):
+    monkeypatch.setattr(health, "_nvml_driver_supported_cuda_version", lambda: None)
     monkeypatch.setattr(health, "_run_nvidia_smi", lambda *_args: None)
     monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
-    monkeypatch.delenv("CUDA_VERSION", raising=False)
     monkeypatch.delenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE", raising=False)
     monkeypatch.delitem(sys.modules, "torch", raising=False)
 
@@ -58,7 +120,6 @@ def test_collect_health_metadata_degrades_without_nvidia(monkeypatch):
         "hardware": {
             "cuda": {
                 "driver_supported_version": None,
-                "container_version": None,
                 "torch_build_version": None,
             },
             "gpus": [],
@@ -68,6 +129,7 @@ def test_collect_health_metadata_degrades_without_nvidia(monkeypatch):
 
 
 def test_collect_health_metadata_reports_detectable_mps_limit(monkeypatch):
+    monkeypatch.setattr(health, "_nvml_driver_supported_cuda_version", lambda: None)
     monkeypatch.setattr(health, "_run_nvidia_smi", lambda *_args: "")
     monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
     monkeypatch.setenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE", "50")
@@ -89,19 +151,25 @@ def test_cached_health_refreshes_torch_version_without_reprobing_host(monkeypatc
         return ""
 
     health._get_host_metadata.cache_clear()
+    monkeypatch.setattr(health, "_nvml_driver_supported_cuda_version", lambda: None)
     monkeypatch.setattr(health, "_run_nvidia_smi", run_nvidia_smi)
     monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
     monkeypatch.delitem(sys.modules, "torch", raising=False)
 
     first = health.get_health_metadata()
-    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(version=SimpleNamespace(cuda="12.6")))
+    monkeypatch.setitem(
+        sys.modules, "torch", SimpleNamespace(version=SimpleNamespace(cuda="12.6"))
+    )
     second = health.get_health_metadata()
 
     assert first["hardware"]["cuda"]["torch_build_version"] is None
     assert second["hardware"]["cuda"]["torch_build_version"] == "12.6"
     assert calls == [
-        (),
-        ("--query-gpu=name,driver_version,compute_cap", "--format=csv,noheader,nounits"),
+        ("-q",),
+        (
+            "--query-gpu=name,driver_version,compute_cap",
+            "--format=csv,noheader,nounits",
+        ),
         ("-L",),
     ]
     health._get_host_metadata.cache_clear()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -6,6 +6,19 @@ import pytest
 from maestro_worker_python import health
 
 
+def _initialized_torch(cuda_version="12.4", sm_count=30):
+    return SimpleNamespace(
+        version=SimpleNamespace(cuda=cuda_version),
+        cuda=SimpleNamespace(
+            is_initialized=lambda: True,
+            current_device=lambda: 0,
+            get_device_properties=lambda _device: SimpleNamespace(
+                multi_processor_count=sm_count
+            ),
+        ),
+    )
+
+
 @pytest.fixture
 def nvml_host(monkeypatch):
     lifecycle = []
@@ -162,6 +175,7 @@ def test_collect_health_metadata_degrades_without_nvidia(monkeypatch, nvml_host)
 def test_collect_health_metadata_reports_configured_mps_limits(monkeypatch, nvml_host):
     monkeypatch.setenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE", "50")
     monkeypatch.setenv("CUDA_MPS_PINNED_DEVICE_MEM_LIMIT", "0=11517M")
+    monkeypatch.setitem(sys.modules, "torch", _initialized_torch())
 
     metadata = health.collect_health_metadata()
 
@@ -169,6 +183,7 @@ def test_collect_health_metadata_reports_configured_mps_limits(monkeypatch, nvml
         "method": "mps",
         "configured_active_thread_percentage": 50,
         "configured_pinned_device_memory_limit": "0=11517M",
+        "observed_sm_count": 30,
         "partition_count": None,
     }
     assert nvml_host == ["init", "shutdown"]
@@ -177,6 +192,16 @@ def test_collect_health_metadata_reports_configured_mps_limits(monkeypatch, nvml
 def test_collect_health_metadata_detects_mps_from_memory_limit(monkeypatch, nvml_host):
     monkeypatch.setenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE", "invalid")
     monkeypatch.setenv("CUDA_MPS_PINNED_DEVICE_MEM_LIMIT", "0=11517M")
+    monkeypatch.setitem(
+        sys.modules,
+        "torch",
+        SimpleNamespace(
+            cuda=SimpleNamespace(
+                is_initialized=lambda: False,
+                current_device=lambda: pytest.fail("health must not initialize CUDA"),
+            )
+        ),
+    )
 
     metadata = health.collect_health_metadata()
 
@@ -184,24 +209,26 @@ def test_collect_health_metadata_detects_mps_from_memory_limit(monkeypatch, nvml
         "method": "mps",
         "configured_active_thread_percentage": None,
         "configured_pinned_device_memory_limit": "0=11517M",
+        "observed_sm_count": None,
         "partition_count": None,
     }
     assert nvml_host == ["init", "shutdown"]
 
 
-def test_cached_health_refreshes_torch_version_without_reprobing_host(
+def test_cached_health_refreshes_torch_metadata_without_reprobing_host(
     monkeypatch, nvml_host
 ):
     health._get_host_metadata.cache_clear()
     monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
+    monkeypatch.setenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE", "50")
 
     first = health.get_health_metadata()
-    monkeypatch.setitem(
-        sys.modules, "torch", SimpleNamespace(version=SimpleNamespace(cuda="12.6"))
-    )
+    monkeypatch.setitem(sys.modules, "torch", _initialized_torch("12.6", 30))
     second = health.get_health_metadata()
 
     assert first["hardware"]["cuda"]["torch_build_version"] is None
+    assert first["hardware"]["partitioning"]["observed_sm_count"] is None
     assert second["hardware"]["cuda"]["torch_build_version"] == "12.6"
+    assert second["hardware"]["partitioning"]["observed_sm_count"] == 30
     assert nvml_host == ["init", "shutdown"]
     health._get_host_metadata.cache_clear()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -24,6 +24,7 @@ def nvml_host(monkeypatch):
         lambda *_args: pytest.fail("nvidia-smi fallback should not run"),
     )
     monkeypatch.delenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE", raising=False)
+    monkeypatch.delenv("CUDA_MPS_PINNED_DEVICE_MEM_LIMIT", raising=False)
     monkeypatch.delitem(sys.modules, "torch", raising=False)
     return lifecycle
 
@@ -158,14 +159,31 @@ def test_collect_health_metadata_degrades_without_nvidia(monkeypatch, nvml_host)
     assert nvml_host == []
 
 
-def test_collect_health_metadata_reports_detectable_mps_limit(monkeypatch, nvml_host):
+def test_collect_health_metadata_reports_configured_mps_limits(monkeypatch, nvml_host):
     monkeypatch.setenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE", "50")
+    monkeypatch.setenv("CUDA_MPS_PINNED_DEVICE_MEM_LIMIT", "0=11517M")
 
     metadata = health.collect_health_metadata()
 
     assert metadata["hardware"]["partitioning"] == {
         "method": "mps",
-        "active_thread_percentage": 50,
+        "configured_active_thread_percentage": 50,
+        "configured_pinned_device_memory_limit": "0=11517M",
+        "partition_count": None,
+    }
+    assert nvml_host == ["init", "shutdown"]
+
+
+def test_collect_health_metadata_detects_mps_from_memory_limit(monkeypatch, nvml_host):
+    monkeypatch.setenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE", "invalid")
+    monkeypatch.setenv("CUDA_MPS_PINNED_DEVICE_MEM_LIMIT", "0=11517M")
+
+    metadata = health.collect_health_metadata()
+
+    assert metadata["hardware"]["partitioning"] == {
+        "method": "mps",
+        "configured_active_thread_percentage": None,
+        "configured_pinned_device_memory_limit": "0=11517M",
         "partition_count": None,
     }
     assert nvml_host == ["init", "shutdown"]

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,8 +1,13 @@
+import sys
+from types import SimpleNamespace
+
 from maestro_worker_python import health
 
 
 def test_collect_health_metadata_reports_gpu_and_mig(monkeypatch):
     def run_nvidia_smi(*args):
+        if not args:
+            return "| NVIDIA-SMI 570.148.08  Driver Version: 570.148.08  CUDA Version: 13.3 |\n"
         if args == ("--query-gpu=name,driver_version,compute_cap", "--format=csv,noheader,nounits"):
             return "NVIDIA L4, 570.148.08, 8.9\n"
         if args == ("-L",):
@@ -16,11 +21,16 @@ def test_collect_health_metadata_reports_gpu_and_mig(monkeypatch):
     monkeypatch.setattr(health, "_run_nvidia_smi", run_nvidia_smi)
     monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
     monkeypatch.setenv("CUDA_VERSION", "13.0.2")
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(version=SimpleNamespace(cuda="12.4")))
 
     assert health.collect_health_metadata() == {
         "worker_version": "4.2.0",
         "hardware": {
-            "cuda_version": "13.0.2",
+            "cuda": {
+                "driver_supported_version": "13.3",
+                "container_version": "13.0.2",
+                "torch_build_version": "12.4",
+            },
             "gpus": [
                 {
                     "model": "NVIDIA L4",
@@ -41,11 +51,16 @@ def test_collect_health_metadata_degrades_without_nvidia(monkeypatch):
     monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
     monkeypatch.delenv("CUDA_VERSION", raising=False)
     monkeypatch.delenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE", raising=False)
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
 
     assert health.collect_health_metadata() == {
         "worker_version": "4.2.0",
         "hardware": {
-            "cuda_version": None,
+            "cuda": {
+                "driver_supported_version": None,
+                "container_version": None,
+                "torch_build_version": None,
+            },
             "gpus": [],
             "partitioning": None,
         },
@@ -64,3 +79,29 @@ def test_collect_health_metadata_reports_detectable_mps_limit(monkeypatch):
         "active_thread_percentage": 50,
         "partition_count": None,
     }
+
+
+def test_cached_health_refreshes_torch_version_without_reprobing_host(monkeypatch):
+    calls = []
+
+    def run_nvidia_smi(*args):
+        calls.append(args)
+        return ""
+
+    health._get_host_metadata.cache_clear()
+    monkeypatch.setattr(health, "_run_nvidia_smi", run_nvidia_smi)
+    monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+
+    first = health.get_health_metadata()
+    monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(version=SimpleNamespace(cuda="12.6")))
+    second = health.get_health_metadata()
+
+    assert first["hardware"]["cuda"]["torch_build_version"] is None
+    assert second["hardware"]["cuda"]["torch_build_version"] == "12.6"
+    assert calls == [
+        (),
+        ("--query-gpu=name,driver_version,compute_cap", "--format=csv,noheader,nounits"),
+        ("-L",),
+    ]
+    health._get_host_metadata.cache_clear()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -6,81 +6,54 @@ import pytest
 from maestro_worker_python import health
 
 
-def test_nvml_driver_supported_cuda_version(monkeypatch):
-    calls = []
-
-    monkeypatch.setattr(health.pynvml, "nvmlInit", lambda: calls.append("init"))
+@pytest.fixture
+def nvml_host(monkeypatch):
+    lifecycle = []
+    monkeypatch.setattr(health.pynvml, "nvmlInit", lambda: lifecycle.append("init"))
     monkeypatch.setattr(
-        health.pynvml,
-        "nvmlSystemGetCudaDriverVersion_v2",
-        lambda: calls.append("query") or 13030,
+        health.pynvml, "nvmlShutdown", lambda: lifecycle.append("shutdown")
     )
-    monkeypatch.setattr(health.pynvml, "nvmlShutdown", lambda: calls.append("shutdown"))
-
-    assert health._nvml_driver_supported_cuda_version() == "13.3"
-    assert calls == ["init", "query", "shutdown"]
-
-
-def test_nvml_driver_supported_cuda_version_shuts_down_after_query_error(monkeypatch):
-    calls = []
-
-    def query():
-        calls.append("query")
-        raise health.pynvml.NVMLError(health.pynvml.NVML_ERROR_UNKNOWN)
-
-    monkeypatch.setattr(health.pynvml, "nvmlInit", lambda: calls.append("init"))
-    monkeypatch.setattr(health.pynvml, "nvmlSystemGetCudaDriverVersion_v2", query)
-    monkeypatch.setattr(health.pynvml, "nvmlShutdown", lambda: calls.append("shutdown"))
-
-    assert health._nvml_driver_supported_cuda_version() is None
-    assert calls == ["init", "query", "shutdown"]
-
-
-def test_nvml_driver_supported_cuda_version_degrades_when_initialization_fails(
-    monkeypatch,
-):
-    def init():
-        raise health.pynvml.NVMLError(health.pynvml.NVML_ERROR_LIBRARY_NOT_FOUND)
-
-    monkeypatch.setattr(health.pynvml, "nvmlInit", init)
+    monkeypatch.setattr(health.pynvml, "nvmlSystemGetDriverVersion", lambda: "610.12")
     monkeypatch.setattr(
-        health.pynvml,
-        "nvmlShutdown",
-        lambda: pytest.fail("NVML must not be shut down after failed initialization"),
+        health.pynvml, "nvmlSystemGetCudaDriverVersion_v2", lambda: 13030
     )
-
-    assert health._nvml_driver_supported_cuda_version() is None
-
-
-@pytest.mark.parametrize("label", ["CUDA Version", "CUDA UMD Version"])
-def test_driver_supported_cuda_version_falls_back_to_nvidia_smi(monkeypatch, label):
-    monkeypatch.setattr(health, "_nvml_driver_supported_cuda_version", lambda: None)
+    monkeypatch.setattr(health.pynvml, "nvmlDeviceGetCount", lambda: 0)
     monkeypatch.setattr(
         health,
         "_run_nvidia_smi",
-        lambda *args: f"{label} : 13.3\n" if args == ("-q",) else None,
+        lambda *_args: pytest.fail("nvidia-smi fallback should not run"),
     )
+    monkeypatch.delenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE", raising=False)
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+    return lifecycle
 
-    assert health._driver_supported_cuda_version() == "13.3"
 
+def test_collect_health_metadata_reports_nvml_gpu_and_visible_mig(
+    monkeypatch, nvml_host
+):
+    def mig_device(_device, index):
+        if index in {0, 2}:
+            return f"mig-{index}"
+        raise health.pynvml.NVMLError(health.pynvml.NVML_ERROR_NOT_FOUND)
 
-def test_collect_health_metadata_reports_gpu_and_mig(monkeypatch):
-    def run_nvidia_smi(*args):
-        if args == (
-            "--query-gpu=name,driver_version,compute_cap",
-            "--format=csv,noheader,nounits",
-        ):
-            return "NVIDIA L4, 570.148.08, 8.9\n"
-        if args == ("-L",):
-            return (
-                "GPU 0: NVIDIA A100 (UUID: GPU-1)\n"
-                "  MIG 1g.10gb Device 0: (UUID: MIG-1)\n"
-                "  MIG 1g.10gb Device 1: (UUID: MIG-2)\n"
-            )
-        raise AssertionError(args)
-
-    monkeypatch.setattr(health, "_nvml_driver_supported_cuda_version", lambda: "13.3")
-    monkeypatch.setattr(health, "_run_nvidia_smi", run_nvidia_smi)
+    monkeypatch.setattr(health.pynvml, "nvmlDeviceGetCount", lambda: 1)
+    monkeypatch.setattr(
+        health.pynvml, "nvmlDeviceGetHandleByIndex", lambda _index: "gpu-0"
+    )
+    monkeypatch.setattr(
+        health.pynvml, "nvmlDeviceGetName", lambda _device: "NVIDIA H100"
+    )
+    monkeypatch.setattr(
+        health.pynvml,
+        "nvmlDeviceGetCudaComputeCapability",
+        lambda _device: (9, 0),
+    )
+    monkeypatch.setattr(
+        health.pynvml, "nvmlDeviceGetMaxMigDeviceCount", lambda _device: 3
+    )
+    monkeypatch.setattr(
+        health.pynvml, "nvmlDeviceGetMigDeviceHandleByIndex", mig_device
+    )
     monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
     monkeypatch.setitem(
         sys.modules, "torch", SimpleNamespace(version=SimpleNamespace(cuda="12.4"))
@@ -89,35 +62,91 @@ def test_collect_health_metadata_reports_gpu_and_mig(monkeypatch):
     assert health.collect_health_metadata() == {
         "worker_version": "4.2.0",
         "hardware": {
+            "nvidia_driver_version": "610.12",
             "cuda": {
                 "driver_supported_version": "13.3",
                 "torch_build_version": "12.4",
             },
-            "gpus": [
-                {
-                    "model": "NVIDIA L4",
-                    "driver_version": "570.148.08",
-                    "sm_version": "sm_89",
-                }
-            ],
+            "gpus": [{"model": "NVIDIA H100", "sm_version": "sm_90"}],
             "partitioning": {
                 "method": "mig",
                 "visible_partition_count": 2,
             },
         },
     }
+    assert nvml_host == ["init", "shutdown"]
 
 
-def test_collect_health_metadata_degrades_without_nvidia(monkeypatch):
-    monkeypatch.setattr(health, "_nvml_driver_supported_cuda_version", lambda: None)
+@pytest.mark.parametrize("label", ["CUDA Version", "CUDA UMD Version"])
+def test_collect_health_metadata_falls_back_for_cuda_driver_version(
+    monkeypatch, nvml_host, label
+):
+    def cuda_driver_version():
+        raise health.pynvml.NVMLError(health.pynvml.NVML_ERROR_FUNCTION_NOT_FOUND)
+
+    monkeypatch.setattr(
+        health.pynvml, "nvmlSystemGetCudaDriverVersion_v2", cuda_driver_version
+    )
+    monkeypatch.setattr(
+        health,
+        "_run_nvidia_smi",
+        lambda *args: f"{label} : 13.3\n" if args == ("-q",) else None,
+    )
+
+    metadata = health.collect_health_metadata()
+
+    assert metadata["hardware"]["nvidia_driver_version"] == "610.12"
+    assert metadata["hardware"]["cuda"] == {
+        "driver_supported_version": "13.3",
+        "torch_build_version": None,
+    }
+    assert nvml_host == ["init", "shutdown"]
+
+
+def test_collect_health_metadata_keeps_partial_nvml_results(monkeypatch, nvml_host):
+    def driver_version():
+        raise health.pynvml.NVMLError(health.pynvml.NVML_ERROR_UNKNOWN)
+
+    def model(_device):
+        raise health.pynvml.NVMLError(health.pynvml.NVML_ERROR_UNKNOWN)
+
+    def mig_count(_device):
+        raise health.pynvml.NVMLError(health.pynvml.NVML_ERROR_NOT_SUPPORTED)
+
+    monkeypatch.setattr(health.pynvml, "nvmlSystemGetDriverVersion", driver_version)
+    monkeypatch.setattr(health.pynvml, "nvmlDeviceGetCount", lambda: 1)
+    monkeypatch.setattr(
+        health.pynvml, "nvmlDeviceGetHandleByIndex", lambda _index: "gpu-0"
+    )
+    monkeypatch.setattr(health.pynvml, "nvmlDeviceGetName", model)
+    monkeypatch.setattr(
+        health.pynvml,
+        "nvmlDeviceGetCudaComputeCapability",
+        lambda _device: (8, 9),
+    )
+    monkeypatch.setattr(health.pynvml, "nvmlDeviceGetMaxMigDeviceCount", mig_count)
+
+    metadata = health.collect_health_metadata()
+
+    assert metadata["hardware"]["nvidia_driver_version"] is None
+    assert metadata["hardware"]["cuda"]["driver_supported_version"] == "13.3"
+    assert metadata["hardware"]["gpus"] == [{"model": None, "sm_version": "sm_89"}]
+    assert metadata["hardware"]["partitioning"] is None
+    assert nvml_host == ["init", "shutdown"]
+
+
+def test_collect_health_metadata_degrades_without_nvidia(monkeypatch, nvml_host):
+    def init():
+        raise health.pynvml.NVMLError(health.pynvml.NVML_ERROR_LIBRARY_NOT_FOUND)
+
+    monkeypatch.setattr(health.pynvml, "nvmlInit", init)
     monkeypatch.setattr(health, "_run_nvidia_smi", lambda *_args: None)
     monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
-    monkeypatch.delenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE", raising=False)
-    monkeypatch.delitem(sys.modules, "torch", raising=False)
 
     assert health.collect_health_metadata() == {
         "worker_version": "4.2.0",
         "hardware": {
+            "nvidia_driver_version": None,
             "cuda": {
                 "driver_supported_version": None,
                 "torch_build_version": None,
@@ -126,12 +155,10 @@ def test_collect_health_metadata_degrades_without_nvidia(monkeypatch):
             "partitioning": None,
         },
     }
+    assert nvml_host == []
 
 
-def test_collect_health_metadata_reports_detectable_mps_limit(monkeypatch):
-    monkeypatch.setattr(health, "_nvml_driver_supported_cuda_version", lambda: None)
-    monkeypatch.setattr(health, "_run_nvidia_smi", lambda *_args: "")
-    monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
+def test_collect_health_metadata_reports_detectable_mps_limit(monkeypatch, nvml_host):
     monkeypatch.setenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE", "50")
 
     metadata = health.collect_health_metadata()
@@ -141,20 +168,14 @@ def test_collect_health_metadata_reports_detectable_mps_limit(monkeypatch):
         "active_thread_percentage": 50,
         "partition_count": None,
     }
+    assert nvml_host == ["init", "shutdown"]
 
 
-def test_cached_health_refreshes_torch_version_without_reprobing_host(monkeypatch):
-    calls = []
-
-    def run_nvidia_smi(*args):
-        calls.append(args)
-        return ""
-
+def test_cached_health_refreshes_torch_version_without_reprobing_host(
+    monkeypatch, nvml_host
+):
     health._get_host_metadata.cache_clear()
-    monkeypatch.setattr(health, "_nvml_driver_supported_cuda_version", lambda: None)
-    monkeypatch.setattr(health, "_run_nvidia_smi", run_nvidia_smi)
     monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
-    monkeypatch.delitem(sys.modules, "torch", raising=False)
 
     first = health.get_health_metadata()
     monkeypatch.setitem(
@@ -164,12 +185,5 @@ def test_cached_health_refreshes_torch_version_without_reprobing_host(monkeypatc
 
     assert first["hardware"]["cuda"]["torch_build_version"] is None
     assert second["hardware"]["cuda"]["torch_build_version"] == "12.6"
-    assert calls == [
-        ("-q",),
-        (
-            "--query-gpu=name,driver_version,compute_cap",
-            "--format=csv,noheader,nounits",
-        ),
-        ("-L",),
-    ]
+    assert nvml_host == ["init", "shutdown"]
     health._get_host_metadata.cache_clear()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -32,6 +32,10 @@ def nvml_host(monkeypatch):
     )
     monkeypatch.setattr(health.pynvml, "nvmlDeviceGetCount", lambda: 0)
     monkeypatch.setattr(
+        health.pynvml, "nvmlDeviceIsMigDeviceHandle", lambda _device: False
+    )
+    monkeypatch.setattr(health.pynvml, "nvmlDeviceGetUUID", lambda device: device)
+    monkeypatch.setattr(
         health,
         "_run_nvidia_smi",
         lambda *_args: pytest.fail("nvidia-smi fallback should not run"),
@@ -68,6 +72,22 @@ def test_collect_health_metadata_reports_nvml_gpu_and_visible_mig(
     monkeypatch.setattr(
         health.pynvml, "nvmlDeviceGetMigDeviceHandleByIndex", mig_device
     )
+    monkeypatch.setattr(
+        health.pynvml,
+        "nvmlDeviceGetAttributes",
+        lambda device: {
+            "mig-0": SimpleNamespace(
+                gpuInstanceSliceCount=1,
+                computeInstanceSliceCount=1,
+                memorySizeMB=10240,
+            ),
+            "mig-2": SimpleNamespace(
+                gpuInstanceSliceCount=3,
+                computeInstanceSliceCount=1,
+                memorySizeMB=40960,
+            ),
+        }[device],
+    )
     monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
     monkeypatch.setitem(
         sys.modules, "torch", SimpleNamespace(version=SimpleNamespace(cuda="12.4"))
@@ -85,8 +105,106 @@ def test_collect_health_metadata_reports_nvml_gpu_and_visible_mig(
             "partitioning": {
                 "method": "mig",
                 "visible_partition_count": 2,
+                "visible_partitions": [
+                    {
+                        "gpu_instance_slice_count": 1,
+                        "compute_instance_slice_count": 1,
+                        "memory_size_mb": 10240,
+                    },
+                    {
+                        "gpu_instance_slice_count": 3,
+                        "compute_instance_slice_count": 1,
+                        "memory_size_mb": 40960,
+                    },
+                ],
             },
         },
+    }
+    assert nvml_host == ["init", "shutdown"]
+
+
+def test_collect_health_metadata_detects_directly_visible_mig_device(
+    monkeypatch, nvml_host
+):
+    monkeypatch.setattr(health.pynvml, "nvmlDeviceGetCount", lambda: 1)
+    monkeypatch.setattr(
+        health.pynvml, "nvmlDeviceGetHandleByIndex", lambda _index: "mig-0"
+    )
+    monkeypatch.setattr(
+        health.pynvml, "nvmlDeviceIsMigDeviceHandle", lambda _device: True
+    )
+    monkeypatch.setattr(
+        health.pynvml, "nvmlDeviceGetName", lambda _device: "NVIDIA H100 MIG"
+    )
+    monkeypatch.setattr(
+        health.pynvml,
+        "nvmlDeviceGetCudaComputeCapability",
+        lambda _device: (9, 0),
+    )
+    monkeypatch.setattr(
+        health.pynvml,
+        "nvmlDeviceGetMaxMigDeviceCount",
+        lambda _device: pytest.fail("a MIG handle must not be treated as a parent"),
+    )
+    monkeypatch.setattr(
+        health.pynvml,
+        "nvmlDeviceGetAttributes",
+        lambda _device: SimpleNamespace(
+            gpuInstanceSliceCount=3,
+            computeInstanceSliceCount=1,
+            memorySizeMB=40960,
+        ),
+    )
+
+    metadata = health.collect_health_metadata()
+
+    assert metadata["hardware"]["partitioning"] == {
+        "method": "mig",
+        "visible_partition_count": 1,
+        "visible_partitions": [
+            {
+                "gpu_instance_slice_count": 3,
+                "compute_instance_slice_count": 1,
+                "memory_size_mb": 40960,
+            }
+        ],
+    }
+    assert nvml_host == ["init", "shutdown"]
+
+
+def test_collect_health_metadata_keeps_mig_detection_when_attributes_fail(
+    monkeypatch, nvml_host
+):
+    def attributes(_device):
+        raise health.pynvml.NVMLError(health.pynvml.NVML_ERROR_NOT_SUPPORTED)
+
+    monkeypatch.setattr(health.pynvml, "nvmlDeviceGetCount", lambda: 1)
+    monkeypatch.setattr(
+        health.pynvml, "nvmlDeviceGetHandleByIndex", lambda _index: "mig-0"
+    )
+    monkeypatch.setattr(
+        health.pynvml, "nvmlDeviceIsMigDeviceHandle", lambda _device: True
+    )
+    monkeypatch.setattr(health.pynvml, "nvmlDeviceGetName", lambda _device: None)
+    monkeypatch.setattr(
+        health.pynvml,
+        "nvmlDeviceGetCudaComputeCapability",
+        lambda _device: (9, 0),
+    )
+    monkeypatch.setattr(health.pynvml, "nvmlDeviceGetAttributes", attributes)
+
+    metadata = health.collect_health_metadata()
+
+    assert metadata["hardware"]["partitioning"] == {
+        "method": "mig",
+        "visible_partition_count": 1,
+        "visible_partitions": [
+            {
+                "gpu_instance_slice_count": None,
+                "compute_instance_slice_count": None,
+                "memory_size_mb": None,
+            }
+        ],
     }
     assert nvml_host == ["init", "shutdown"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -255,6 +255,7 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "json-logging" },
+    { name = "nvidia-ml-py" },
     { name = "psutil" },
     { name = "pydantic-core" },
     { name = "pydantic-settings", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
@@ -276,6 +277,7 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.100.0,<0.115.13" },
     { name = "json-logging", specifier = ">=1.3,<2" },
+    { name = "nvidia-ml-py", specifier = ">=12.535,<14" },
     { name = "psutil", specifier = ">=6.0.0,<7.1" },
     { name = "pydantic-core", specifier = ">=2.9,<3" },
     { name = "pydantic-settings", specifier = ">=2.9,<3" },
@@ -362,6 +364,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/1b/a7782984844bd519ad4ffdbebbba2671ec5d0ebbeac34736c15fb86399e8/markupsafe-3.0.3-cp39-cp39-win32.whl", hash = "sha256:df2449253ef108a379b8b5d6b43f4b1a8e81a061d6537becd5582fba5f9196d7", size = 14566, upload-time = "2025-09-27T18:37:37.09Z" },
     { url = "https://files.pythonhosted.org/packages/18/1f/8d9c20e1c9440e215a44be5ab64359e207fcb4f675543f1cf9a2a7f648d0/markupsafe-3.0.3-cp39-cp39-win_amd64.whl", hash = "sha256:7c3fb7d25180895632e5d3148dbdc29ea38ccb7fd210aa27acbd1201a1902c6e", size = 15053, upload-time = "2025-09-27T18:37:38.054Z" },
     { url = "https://files.pythonhosted.org/packages/4e/d3/fe08482b5cd995033556d45041a4f4e76e7f0521112a9c9991d40d39825f/markupsafe-3.0.3-cp39-cp39-win_arm64.whl", hash = "sha256:38664109c14ffc9e7437e86b4dceb442b0096dfe3541d7864d9cbe1da4cf36c8", size = 13928, upload-time = "2025-09-27T18:37:39.037Z" },
+]
+
+[[package]]
+name = "nvidia-ml-py"
+version = "13.610.43"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/b5/a8fbc356f768fa5c9cfd646668fd7d34bf55bdd1c6e20754642a64d930d4/nvidia_ml_py-13.610.43.tar.gz", hash = "sha256:65437eb73d68d0c62c931ca4d45038472faff03bd0b8729abba4b899f70d60f2", size = 52109, upload-time = "2026-06-01T18:54:08.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/45/caa600acfab94560807a20a64b5830d2cd3c3202b7f1328644d70b7d6bd8/nvidia_ml_py-13.610.43-py3-none-any.whl", hash = "sha256:f13c72698edef492f985cc225f14faafe68ae065a2e407f45bdf6f4b9b43fde8", size = 53163, upload-time = "2026-06-01T18:54:07.704Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Enrich `/health` with Maestro package version and best-effort GPU metadata (driver, CUDA support, visible GPUs).
- Collect NVIDIA host info via NVML (`nvidia-ml-py`), including MIG partition shape and configured MPS resource limits.
- Report `observed_sm_count` from an already-imported PyTorch CUDA device without initializing CUDA in the health check; prime metadata on startup for readiness probes.

## Test plan
- [x] Run `pytest tests/test_health.py`
- [x] Hit `/health` on a CPU worker and confirm `ok`, package version, and empty `hardware.gpus`
- [x] Hit `/health` on a GPU worker and confirm driver/CUDA/GPU fields populate
- [x] On MIG/MPS setups, confirm partition or configured MPS limits appear as documented in the README