### PR TITLE
fix: report deployed worker version in health

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ curl --request POST --url http://localhost:8000/inference  --header 'Content-Typ
     --data '{"input_1": "Hello"}'
 ```
 
-The `/health` endpoint reports the Maestro worker package version and available
-GPU metadata in addition to `ok`. `nvidia_driver_version` is the host driver,
+The `/health` endpoint reports the worker artifact version supplied through
+`WORKER_VERSION` and available GPU metadata in addition to `ok`. Deployments
+should set it to the exact worker image tag; it is `null` when unset.
+`nvidia_driver_version` is the host driver,
 `driver_supported_version` is the newest CUDA version it supports, and
 `torch_build_version` is the toolkit version used to build an already-imported
 PyTorch. NVIDIA host probing uses NVML and is best-effort, so CPU workers return

--- a/maestro_worker_python/health.py
+++ b/maestro_worker_python/health.py
@@ -3,7 +3,6 @@ import re
 import subprocess
 import sys
 from functools import lru_cache
-from importlib import metadata
 from typing import Any
 
 import pynvml
@@ -230,11 +229,9 @@ def _torch_observed_sm_count() -> int | None:
     return sm_count if isinstance(sm_count, int) and sm_count > 0 else None
 
 
-def _worker_version() -> str:
-    try:
-        return metadata.version("maestro-worker-python")
-    except metadata.PackageNotFoundError:
-        return "unknown"
+def _worker_version() -> str | None:
+    """Return the worker artifact version supplied by the deployment."""
+    return os.getenv("WORKER_VERSION") or None
 
 
 def _collect_host_metadata() -> dict[str, Any]:

--- a/maestro_worker_python/scaffold/README.md
+++ b/maestro_worker_python/scaffold/README.md
@@ -11,7 +11,7 @@ uv sync
 Run the worker locally:
 
 ```bash
-uv run maestro-server --worker worker.py --port 8000 --reload True
+WORKER_VERSION=dev uv run maestro-server --worker worker.py --port 8000 --reload True
 ```
 
 Build and run it in Docker:
@@ -20,6 +20,9 @@ Build and run it in Docker:
 docker compose build
 docker compose up
 ```
+
+`WORKER_VERSION` identifies the worker artifact in `/health`. Docker Compose
+sets it to `dev`; deployments should set it to the exact image tag.
 
 `BASE_IMAGE` must provide a Python interpreter that satisfies the project's
 `requires-python` constraint. Its executable may be named `python`, `python3`,

--- a/maestro_worker_python/scaffold/docker-compose.yaml
+++ b/maestro_worker_python/scaffold/docker-compose.yaml
@@ -5,6 +5,8 @@ services:
       args:
         - BASE_IMAGE
     command: maestro-server --worker /worker/worker.py --port 8000 --reload True
+    environment:
+      WORKER_VERSION: dev
     ports:
       - "8000:8000"
     expose:

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -42,6 +42,7 @@ def nvml_host(monkeypatch):
     )
     monkeypatch.delenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE", raising=False)
     monkeypatch.delenv("CUDA_MPS_PINNED_DEVICE_MEM_LIMIT", raising=False)
+    monkeypatch.delenv("WORKER_VERSION", raising=False)
     monkeypatch.delitem(sys.modules, "torch", raising=False)
     return lifecycle
 
@@ -88,13 +89,13 @@ def test_collect_health_metadata_reports_nvml_gpu_and_visible_mig(
             ),
         }[device],
     )
-    monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
+    monkeypatch.setenv("WORKER_VERSION", "git-abc123")
     monkeypatch.setitem(
         sys.modules, "torch", SimpleNamespace(version=SimpleNamespace(cuda="12.4"))
     )
 
     assert health.collect_health_metadata() == {
-        "worker_version": "4.2.0",
+        "worker_version": "git-abc123",
         "hardware": {
             "nvidia_driver_version": "610.12",
             "cuda": {
@@ -273,10 +274,8 @@ def test_collect_health_metadata_degrades_without_nvidia(monkeypatch, nvml_host)
 
     monkeypatch.setattr(health.pynvml, "nvmlInit", init)
     monkeypatch.setattr(health, "_run_nvidia_smi", lambda *_args: None)
-    monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
-
     assert health.collect_health_metadata() == {
-        "worker_version": "4.2.0",
+        "worker_version": None,
         "hardware": {
             "nvidia_driver_version": None,
             "cuda": {
@@ -337,7 +336,6 @@ def test_cached_health_refreshes_torch_metadata_without_reprobing_host(
     monkeypatch, nvml_host
 ):
     health._get_host_metadata.cache_clear()
-    monkeypatch.setattr(health.metadata, "version", lambda _name: "4.2.0")
     monkeypatch.setenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE", "50")
 
     first = health.get_health_metadata()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -57,6 +57,7 @@ def test_init_creates_complete_worker_scaffold(tmp_path, monkeypatch):
     compose = (target / "docker-compose.yaml").read_text()
     assert not compose.startswith("version:")
     assert "build:\n      context: .\n      args:\n        - BASE_IMAGE" in compose
+    assert "WORKER_VERSION: dev" in compose
 
     readme = (target / "README.md").read_text()
     assert "## PyTorch workers" in readme


### PR DESCRIPTION
## Summary
- Report `worker_version` from the `WORKER_VERSION` env var (deployed image tag) instead of the `maestro-worker-python` package version
- Return `null` when unset, and wire `WORKER_VERSION=dev` into the scaffold Compose/README docs

## Test plan
- [x] `pytest tests/test_health.py tests/test_init.py`
- [x] Hit `/health` with `WORKER_VERSION` set and unset; confirm `worker_version` matches / is `null`