### PR TITLE
chore: release 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ pip install git+https://github.com/moises-ai/maestro-worker-python.git
 
 To install a version (recommended):
 ```
-pip install git+https://github.com/moises-ai/maestro-worker-python.git@4.0.0
+pip install git+https://github.com/moises-ai/maestro-worker-python.git@5.0.0
 ```
 
 ## Maestro init

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "maestro-worker-python"
-version = "4.0.0"
+version = "5.0.0"
 description = "Utility to run workers on Moises/Maestro"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -191,7 +191,7 @@ wheels = [
 
 [[package]]
 name = "maestro-worker-python"
-version = "4.0.0"
+version = "5.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- Bump package version from `4.0.0` to `5.0.0` in `pyproject.toml`, `uv.lock`, and README install instructions.

## Included since 4.x
- Migrate project tooling and `maestro-init` scaffold to `uv`
- Load workers from files or modules; improve scaffold (incl. PyTorch base images)
- Expose worker hardware health metadata (NVML / MPS / MIG)
- Report deployed worker version in health
- Preserve fractional billable seconds
- Update framework dependencies and add code-quality tooling

## Test plan
- [x] Confirm version is `5.0.0` in `pyproject.toml` and `uv.lock`
- [x] Confirm README install pin points at `@5.0.0`
- [x] After merge/tag, verify `pip install ...@5.0.0` resolves correctly