### PR TITLE
feat: report the deployment worker identity in Sentry, /health, and inference responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,29 @@ Workers return a `WorkerResponse`:
   deployment's own response consumer reads and then removes before answering its
   callers. Its contents are entirely up to that deployment; this library gives it
   no meaning and does not validate it. Leave it unset if nothing consumes it.
+- `worker`: the deployment identity as `{"name": ..., "version": ...}`, stamped by
+  the server. A worker's own value is replaced wholesale rather than merged, so a
+  caller can trust the object to describe the artifact that actually served the
+  request. Always present; its members are `null` when the deployment supplied
+  nothing.
 
 Any other field a worker returns is dropped. `internal` is the one exception, so
 a worker cannot reach a caller with a field nobody agreed to.
 
-The `/health` endpoint reports the worker artifact version supplied through
-`WORKER_VERSION` and available GPU metadata in addition to `ok`. Deployments
-should set it to the exact worker image tag; it is `null` when unset.
+The `/health` endpoint reports the same `worker` object, supplied through
+`WORKER_NAME` and `WORKER_VERSION`, and available GPU metadata in addition to
+`ok`. Deployments should set `WORKER_VERSION` to the exact worker image tag.
+`/health` and the inference response read the same settings, so they cannot
+report different identities for one process.
+
+That same identity configures Sentry, so a deployment gets attributable events
+without configuring Sentry separately: `WORKER_VERSION` becomes the release —
+keeping every event tied to an artifact that can still be pulled and inspected —
+and `WORKER_NAME` becomes both the `worker` tag and part of the grouping
+fingerprint, so each worker gets its own issues instead of workers built on a
+shared base collapsing into one. With `WORKER_VERSION` unset the SDK falls back
+to its own release discovery.
+
 `nvidia_driver_version` is the host driver,
 `driver_supported_version` is the newest CUDA version it supports, and
 `torch_build_version` is the toolkit version used to build an already-imported

--- a/maestro_worker_python/config.py
+++ b/maestro_worker_python/config.py
@@ -9,6 +9,9 @@ class Settings(BaseSettings):
     sentry_traces_sample_rate: float = 1.0
     sentry_errors_sample_rate: float = 1.0
     environment: str = "production"
+    # Feeds /health and Sentry release/tags for the serving artifact.
+    worker_name: str | None = None
+    worker_version: str | None = None
 
 
 settings = Settings()

--- a/maestro_worker_python/health.py
+++ b/maestro_worker_python/health.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import pynvml
 
+from .config import settings
+
 
 def _run_nvidia_smi(*args: str) -> str | None:
     try:
@@ -222,15 +224,13 @@ def _torch_observed_sm_count() -> int | None:
     return sm_count if isinstance(sm_count, int) and sm_count > 0 else None
 
 
-def _worker_version() -> str | None:
-    """Return the worker artifact version supplied by the deployment."""
-    return os.getenv("WORKER_VERSION") or None
-
-
 def _collect_host_metadata() -> dict[str, Any]:
     """Collect stable host metadata without making health depend on a GPU."""
     return {
-        "worker_version": _worker_version(),
+        "worker": {
+            "name": settings.worker_name,
+            "version": settings.worker_version,
+        },
         "hardware": _collect_hardware_metadata(),
     }
 

--- a/maestro_worker_python/response.py
+++ b/maestro_worker_python/response.py
@@ -1,6 +1,13 @@
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+
+class WorkerIdentity(BaseModel):
+    """Which artifact served a request, as reported by its own deployment."""
+
+    name: str | None = None
+    version: str | None = None
 
 
 class WorkerResponse(BaseModel):
@@ -9,6 +16,8 @@ class WorkerResponse(BaseModel):
     result: dict[str, Any]
     # Opaque passthrough for the deployment; other undeclared fields are dropped.
     internal: dict[str, Any] | None = None
+    # Stamped by the server from deployment settings; worker-set values are overwritten.
+    worker: WorkerIdentity = Field(default_factory=WorkerIdentity)
 
 
 class ValidationError(Exception):

--- a/maestro_worker_python/scaffold/README.md
+++ b/maestro_worker_python/scaffold/README.md
@@ -21,8 +21,10 @@ docker compose build
 docker compose up
 ```
 
-`WORKER_VERSION` identifies the worker artifact in `/health`. Docker Compose
-sets it to `dev`; deployments should set it to the exact image tag.
+`WORKER_NAME` and `WORKER_VERSION` identify the worker in the `worker` object of
+`/health` and inference responses, and in Sentry, where the version is reported
+as the release and the name as the `worker` tag. Docker Compose sets them for
+local runs; deployments should set `WORKER_VERSION` to the exact image tag.
 
 `BASE_IMAGE` must provide a Python interpreter that satisfies the project's
 `requires-python` constraint. Its executable may be named `python`, `python3`,

--- a/maestro_worker_python/scaffold/docker-compose.yaml
+++ b/maestro_worker_python/scaffold/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
         - BASE_IMAGE
     command: maestro-server --worker /worker/worker.py --port 8000 --reload True
     environment:
+      WORKER_NAME: local
       WORKER_VERSION: dev
     ports:
       - "8000:8000"

--- a/maestro_worker_python/serve.py
+++ b/maestro_worker_python/serve.py
@@ -35,11 +35,20 @@ def filter_transactions(event, hint):
 
 sentry_sdk.init(
     dsn=settings.sentry_dsn,
+    # Same value /health reports; unset falls back to SENTRY_RELEASE / VCS discovery.
+    release=settings.worker_version,
     traces_sample_rate=settings.sentry_traces_sample_rate,
     sample_rate=settings.sentry_errors_sample_rate,
     environment=settings.environment,
     before_send_transaction=filter_transactions,
 )
+
+if settings.worker_name:
+    # Global scope so the tag survives threadpool work (isolation scope would not).
+    scope = sentry_sdk.get_global_scope()
+    scope.set_tag("worker", settings.worker_name)
+    # Shared family bases share stacktraces; pin grouping to the worker name.
+    scope.fingerprint = ["{{ default }}", settings.worker_name]
 
 
 HTTP_READY_PATH = "/tmp/http_ready"
@@ -117,6 +126,28 @@ async def pydantic_validation_exception_handler(request: Request, exc: pydantic.
     )
 
 
+def _with_worker_identity(result):
+    """Stamp deployment identity onto the worker result.
+
+    Returns a mapping so FastAPI still validates the response model (500 on
+    bad worker output); validating here would turn that into a 400.
+    """
+    identity = {
+        "worker": {
+            "name": settings.worker_name,
+            "version": settings.worker_version,
+        }
+    }
+
+    if isinstance(result, pydantic.BaseModel):
+        return {**result.model_dump(), **identity}
+
+    if isinstance(result, dict):
+        return {**result, **identity}
+
+    return result
+
+
 @app.post("/inference", response_model=WorkerResponse)
 async def inference(request: Request):
     global error_counter
@@ -124,7 +155,7 @@ async def inference(request: Request):
     result = await run_in_threadpool(model.inference, input_data=params)
     async with lock:
         error_counter = 0
-    return result
+    return _with_worker_identity(result)
 
 
 @app.get("/")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "pydantic>=2.9,<3",
   "pydantic-settings>=2.9,<3",
   "requests>=2.31,<3",
-  "sentry-sdk[fastapi]>=1.16,<3",
+  "sentry-sdk[fastapi]>=2,<3",
   "uvicorn>=0.34.0,<0.34.3",
 ]
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -34,7 +34,8 @@ def nvml_host(monkeypatch):
     )
     monkeypatch.delenv("CUDA_MPS_ACTIVE_THREAD_PERCENTAGE", raising=False)
     monkeypatch.delenv("CUDA_MPS_PINNED_DEVICE_MEM_LIMIT", raising=False)
-    monkeypatch.delenv("WORKER_VERSION", raising=False)
+    monkeypatch.setattr(health.settings, "worker_name", None)
+    monkeypatch.setattr(health.settings, "worker_version", None)
     monkeypatch.delitem(sys.modules, "torch", raising=False)
     return lifecycle
 
@@ -71,11 +72,12 @@ def test_collect_health_metadata_reports_nvml_gpu_and_visible_mig(monkeypatch, n
             ),
         }[device],
     )
-    monkeypatch.setenv("WORKER_VERSION", "git-abc123")
+    monkeypatch.setattr(health.settings, "worker_name", "separator-a")
+    monkeypatch.setattr(health.settings, "worker_version", "git-abc123")
     monkeypatch.setitem(sys.modules, "torch", SimpleNamespace(version=SimpleNamespace(cuda="12.4")))
 
     assert health.collect_health_metadata() == {
-        "worker_version": "git-abc123",
+        "worker": {"name": "separator-a", "version": "git-abc123"},
         "hardware": {
             "nvidia_driver_version": "610.12",
             "cuda": {
@@ -235,7 +237,7 @@ def test_collect_health_metadata_degrades_without_nvidia(monkeypatch, nvml_host)
     monkeypatch.setattr(health.pynvml, "nvmlInit", init)
     monkeypatch.setattr(health, "_run_nvidia_smi", lambda *_args: None)
     assert health.collect_health_metadata() == {
-        "worker_version": None,
+        "worker": {"name": None, "version": None},
         "hardware": {
             "nvidia_driver_version": None,
             "cuda": {

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -51,6 +51,7 @@ def test_init_creates_complete_worker_scaffold(tmp_path, monkeypatch):
     compose = (target / "docker-compose.yaml").read_text()
     assert not compose.startswith("version:")
     assert "build:\n      context: .\n      args:\n        - BASE_IMAGE" in compose
+    assert "WORKER_NAME: local" in compose
     assert "WORKER_VERSION: dev" in compose
 
     readme = (target / "README.md").read_text()

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1,12 +1,79 @@
 import asyncio
 import importlib
 import sys
+import threading
 from pathlib import Path
 
 import pytest
+import sentry_sdk
 from fastapi.testclient import TestClient
+from sentry_sdk.transport import Transport
 
 from maestro_worker_python.config import settings
+from maestro_worker_python.health import collect_health_metadata
+from maestro_worker_python.response import WorkerResponse
+
+
+class _RecordingScope:
+    def __init__(self):
+        self.tags: dict[str, str] = {}
+        self.fingerprint = None
+
+    def set_tag(self, key, value):
+        self.tags[key] = value
+
+
+def _capture_sentry(monkeypatch: pytest.MonkeyPatch):
+    """Record what serve.py's import-time Sentry configuration would do."""
+    options: dict = {}
+    scope = _RecordingScope()
+    monkeypatch.setattr(sentry_sdk, "init", lambda **kwargs: options.update(kwargs))
+    monkeypatch.setattr(sentry_sdk, "get_global_scope", lambda: scope)
+    return options, scope
+
+
+class _CapturingTransport(Transport):
+    """Transport subclass rather than a function transport, which is deprecated."""
+
+    def __init__(self, events):
+        super().__init__()
+        self.events = events
+
+    def capture_envelope(self, envelope):
+        for item in envelope.items:
+            event = item.get_event()
+            if event is not None:
+                self.events.append(event)
+
+
+@pytest.fixture
+def sentry_events(monkeypatch: pytest.MonkeyPatch):
+    """Run the real SDK against a capturing transport, not a stubbed init.
+
+    Release, tags, and fingerprint are only meaningful if the SDK actually
+    applies them to an event, which depends on scope semantics a stub cannot
+    reproduce.
+    """
+    events: list[dict] = []
+    real_init = sentry_sdk.init
+
+    def init(**options):
+        # A dsn is required for the client to be active at all; example.invalid is
+        # unresolvable and the capturing transport is what keeps this off the network.
+        options["dsn"] = "https://key@example.invalid/1"
+        transport = _CapturingTransport(events)
+        options["transport"] = transport
+        result = real_init(**options)
+        assert sentry_sdk.get_client().transport is transport, "would send real events"
+        return result
+
+    monkeypatch.setattr(sentry_sdk, "init", init)
+    yield events
+    # The client and the global scope outlive the test; drop both so later tests
+    # neither report into this transport nor inherit its identity.
+    sentry_sdk.get_global_scope().clear()
+    real_init(dsn=None)
+
 
 # Deliberately mixed value types: `internal` is typed only as an object, so
 # coercion of anything inside it would be a silent corruption of a channel this
@@ -123,3 +190,97 @@ def test_inference_distinguishes_an_empty_internal_object_from_no_internal_objec
 
     assert empty["internal"] == {}
     assert unset["internal"] is None
+
+
+def test_sentry_events_carry_the_worker_identity_from_a_worker_thread(tmp_path, monkeypatch, sentry_events):
+    monkeypatch.setattr(settings, "worker_name", "dmx-bass-xl-a")
+    monkeypatch.setattr(settings, "worker_version", "d41d8cd98f00b204")
+    worker_path = tmp_path / "worker.py"
+    worker_path.write_text("class MoisesWorker:\n    pass\n")
+
+    _import_serve(monkeypatch, worker_path)
+
+    # inference() hands the worker body to a threadpool, so the identity has to
+    # survive leaving the request's own scope.
+    def capture_from_thread():
+        try:
+            raise RuntimeError("boom")
+        except RuntimeError:
+            sentry_sdk.capture_exception()
+
+    thread = threading.Thread(target=capture_from_thread)
+    thread.start()
+    thread.join()
+    sentry_sdk.flush()
+
+    (event,) = sentry_events
+    # The release must stay the value /health reports for the same process.
+    assert event["release"] == "d41d8cd98f00b204"
+    assert collect_health_metadata()["worker"]["version"] == "d41d8cd98f00b204"
+    assert event["tags"]["worker"] == "dmx-bass-xl-a"
+    # Grouping is per worker, so one family base cannot collapse the fleet into
+    # a single issue.
+    assert event["fingerprint"] == ["{{ default }}", "dmx-bass-xl-a"]
+
+
+def test_sentry_keeps_its_own_release_discovery_when_identity_is_unset(tmp_path, monkeypatch):
+    options, scope = _capture_sentry(monkeypatch)
+    monkeypatch.setattr(settings, "worker_name", None)
+    monkeypatch.setattr(settings, "worker_version", None)
+    worker_path = tmp_path / "worker.py"
+    worker_path.write_text("class MoisesWorker:\n    pass\n")
+
+    _import_serve(monkeypatch, worker_path)
+
+    assert options["release"] is None
+    assert scope.tags == {}
+    assert scope.fingerprint is None
+
+
+def test_inference_stamps_the_deployment_identity_over_worker_supplied_values(serve_module, monkeypatch):
+    monkeypatch.setattr(settings, "worker_name", "dmx-bass-xl-a")
+    monkeypatch.setattr(settings, "worker_version", "d41d8cd98f00b204")
+
+    # A worker supplying a partial identity has the whole object replaced, not
+    # merged, so a spoofed member cannot survive alongside a stamped one.
+    from_dict = serve_module._with_worker_identity(
+        {"billable_seconds": 1.0, "stats": {}, "result": {"ok": True}, "worker": {"version": "spoofed"}}
+    )
+    from_model = serve_module._with_worker_identity(WorkerResponse(billable_seconds=1.0, stats={}, result={"ok": True}))
+
+    for stamped in (from_dict, from_model):
+        assert stamped["worker"] == {"name": "dmx-bass-xl-a", "version": "d41d8cd98f00b204"}
+        assert stamped["result"] == {"ok": True}
+
+
+def test_inference_leaves_unrecognized_worker_return_shapes_alone(serve_module, monkeypatch):
+    monkeypatch.setattr(settings, "worker_version", "d41d8cd98f00b204")
+
+    assert serve_module._with_worker_identity(None) is None
+
+
+def test_inference_and_health_report_the_identity_over_http(tmp_path, monkeypatch):
+    """The response envelope is a cross-service contract, so pin the wire shape."""
+    monkeypatch.setattr(settings, "worker_name", "dmx-bass-xl-a")
+    monkeypatch.setattr(settings, "worker_version", "d41d8cd98f00b204")
+    worker_path = tmp_path / "worker.py"
+    worker_path.write_text(
+        "class MoisesWorker:\n"
+        "    def inference(self, input_data):\n"
+        "        return {\n"
+        '            "billable_seconds": 2.0,\n'
+        '            "stats": {"duration": 0.5},\n'
+        '            "result": {"echo": input_data},\n'
+        "        }\n"
+    )
+    serve_module = _import_serve(monkeypatch, worker_path)
+    client = TestClient(serve_module.app)
+
+    inference = client.post("/inference", json={"input_url": "gs://bucket/song.mp3"}).json()
+    health = client.get("/health").json()
+
+    assert inference["worker"] == {"name": "dmx-bass-xl-a", "version": "d41d8cd98f00b204"}
+    assert inference["result"] == {"echo": {"input_url": "gs://bucket/song.mp3"}}
+    assert inference["billable_seconds"] == 2.0
+    # Both surfaces read one Settings field each, so they cannot disagree.
+    assert health["worker"] == inference["worker"]

--- a/uv.lock
+++ b/uv.lock
@@ -252,7 +252,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.9,<3" },
     { name = "pydantic-settings", specifier = ">=2.9,<3" },
     { name = "requests", specifier = ">=2.31,<3" },
-    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=1.16,<3" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2,<3" },
     { name = "uvicorn", specifier = ">=0.34.0,<0.34.3" },
 ]
 


### PR DESCRIPTION
WORKER_NAME and WORKER_VERSION become first-class settings. The version is the Sentry release and the name is both the 'worker' tag and part of the grouping fingerprint, so events name an artifact that can still be pulled and each worker owns its issues instead of a shared family base collapsing the fleet into one. /health and the inference envelope report the same values from the same fields, so the three cannot drift.

Narrows sentry-sdk to >=2: the worker body runs in a threadpool, and only the 2.x global scope is guaranteed to merge tags into events raised outside a request's own isolation scope.