### PR TITLE
chore: let uv 0.12 build with its built-in backend

### DIFF
--- a/maestro_worker_python/scaffold/Dockerfile
+++ b/maestro_worker_python/scaffold/Dockerfile
@@ -3,7 +3,7 @@
 ARG BASE_IMAGE=python:3.12-slim-trixie
 FROM ${BASE_IMAGE}
 
-COPY --from=ghcr.io/astral-sh/uv:0.11.25 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.12.1 /uv /uvx /bin/
 
 ENV UV_LINK_MODE=copy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.11.25,<0.12"]
+requires = ["uv_build>=0.11.25,<0.13"]
 build-backend = "uv_build"
 
 [tool.ruff]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -35,7 +35,7 @@ def test_init_creates_complete_worker_scaffold(tmp_path, monkeypatch):
     dockerfile = (target / "Dockerfile").read_text()
     assert "ARG BASE_IMAGE=python:3.12-slim-trixie" in dockerfile
     assert "FROM ${BASE_IMAGE}" in dockerfile
-    assert "COPY --from=ghcr.io/astral-sh/uv:0.11.25 /uv /uvx /bin/" in dockerfile
+    assert "COPY --from=ghcr.io/astral-sh/uv:0.12.1 /uv /uvx /bin/" in dockerfile
     assert "UV_LINK_MODE=copy" in dockerfile
     assert "COPY pyproject.toml uv.lock ./" in dockerfile
     assert "--mount=type=cache,target=/root/.cache/uv" in dockerfile


### PR DESCRIPTION
Building this package with uv 0.12.x printed:

```
warning: `build_system.requires = ["uv-build>=0.11.25,<0.12"]` does not contain the current uv version 0.12.1
```

When its own version falls outside the declared range, uv can't use the `uv_build` backend compiled into the binary and falls back to an isolated PEP 517 build that downloads the backend from PyPI. Scaffolded workers install `maestro-worker-python` from a GitHub source tarball, so that fallback ran on every worker image build.

- Widen the `uv_build` ceiling to `<0.13`.
- Bump the scaffold Dockerfile's uv image to 0.12.1 so newly generated workers don't reintroduce the mismatch, with `tests/test_init.py` following the tag.

The downstream effect only lands once a release tag carries the new ceiling; existing worker repos keep their own committed `0.11.25` Dockerfile pin.

Verified with `uv sync --locked --all-groups` (rebuilds clean, no warning) and `uv run pytest`.